### PR TITLE
Block search engine indexing while not public

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.netlify
 build
 node_modules

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -9,6 +9,8 @@ export default defineConfig({
   description: 'Docs | Guides | Tutorials',
   head: [
     ['link', { rel: 'icon', type: 'image/svg+xml', href: '/img/sb-dev-logo.svg' }],
+    // TODO: remove before making public
+    ['meta', { name: 'robots', content: 'noindex,nofollow,noarchive' }],
     /*
     ['meta', { property: 'og:type', content: 'website' }],
     ['meta', { property: 'og:title', content: ogTitle }],


### PR DESCRIPTION
This adds a `<meta name="robots" content="noindex,nofollow,noarchive">` tag to the doc's HTML pages.

Why?

Because this repository gets deployed to https://stackblitz-docs.netlify.app/ (and other domains for branch deploy previews), and while Netlify adds a `X-Robots-Tag: noindex` HTTP header for deploy previews, it doesn't for the main preview (https://stackblitz-docs.netlify.app/).

For a pre-release site, we have two options:

1. Password-protect the site, so that search engines can't access it.
2. Or set a `noindex` header or tag.

I went with the second one for convenience of sharing our progress internally (no password required).

We will have to remove that meta tag when going live though. I'll make a Linear issue for that.