### PR TITLE
Add Google Tag Manager

### DIFF
--- a/.vitepress/analytics.ts
+++ b/.vitepress/analytics.ts
@@ -1,0 +1,5 @@
+const GTM_ID = 'G-79VJSP1Z7C';
+
+export const GTAG_URL = `https://www.googletagmanager.com/gtag/js?id=${GTM_ID}`;
+
+export const GTAG_INIT = `function gtag(){dataLayer.push(arguments)}window.dataLayer=window.dataLayer||[],gtag('js',new Date),gtag('config','${GTM_ID}',{anonymize_ip:true})`;

--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from 'vitepress';
 
 import * as data from '../docs/data';
+import { GTAG_INIT, GTAG_URL } from './analytics';
 
 export default defineConfig({
   // Metadata
@@ -21,6 +22,8 @@ export default defineConfig({
     */
     // TODO: remove before making public
     ['meta', { name: 'robots', content: 'noindex,nofollow,noarchive' }],
+    ['script', { src: GTAG_URL, async: '' }],
+    ['script', {}, GTAG_INIT],
   ],
 
   srcDir: 'docs',


### PR DESCRIPTION
What it says on the tin.

We're using the GTM tracking id from developer.stackblitz.com rather than making a new property in Google Analytics.
