### PR TITLE
Add redirects for top-level paths that don't have a page

### DIFF
--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -1,6 +1,12 @@
-# Older redirects, can maybe be removed?
-/docs/platform  /
-/docs/platform/supported-frameworks  /guides/user-guide/starter-projects
+# Redirect bare section paths to their first page
+/codeflow   /codeflow/what-is-codeflow
+/enterprise   /enterprise/overview
+/guides   /guides/user-guide/what-is-stackblitz
+/guides/user-guide  /guides/user-guide/what-is-stackblitz
+/guides/integration   /guides/integration/embedding
+/platform   /
+/platform/api   /platform/api/javascript-sdk
+/platform/webcontainers   /platform/webcontainers/browser-support
 
 # Redirect old URL patterns
 /docs/enterprise   /enterprise/overview
@@ -47,3 +53,7 @@
 /docs/platform/turbo/   /platform/webcontainers/turbo-package-manager
 /docs/platform/webcontainer-api/   /platform/api/webcontainer-api
 /docs/platform/what-is-stackblitz/   /guides/user-guide/what-is-stackblitz
+
+# Older redirects, can maybe be removed?
+/docs/platform  /
+/docs/platform/supported-frameworks  /guides/user-guide/starter-projects


### PR DESCRIPTION
# PR Description

This PR fixes the issue number: no issue.

### Summary of my changes and explanation of my decisions

- Adds redirects for paths like `/codeflow` and `/guides/user-guide` to actual pages (the first page of each section).

### Self-check

Please check all that apply:

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my code or content update and edited it to the best of my abilities
- [x] I have commented my code, particularly in hard-to-understand areas; my comments are concise

### Contributors list

Would you like your contribution to be celebrated? Please check all that apply:

- [ ] I would like to be featured on the future contributors list in the README. If so, please tell us:
  - what name you'd like to be shown there?
  - we usually link github profile pic -- is that ok? If not, provide another url: 
  - we usually link your github profile but if you have a portfolio page, provide a link:

- [ ] I would like to get a shoutout in the next monthly updates post. If so, please provide your twitter handle (or we will link to your GitHub profile).

⚡️ ⚡️ ⚡️  Thank you for contributing to StackBlitz ⚡️ ⚡️ ⚡️ 
