### PR TITLE
Move edit link hack to a dedicated script module

### DIFF
--- a/.vitepress/theme/index.ts
+++ b/.vitepress/theme/index.ts
@@ -1,14 +1,7 @@
 import DefaultTheme from 'vitepress/theme';
 
+import './scripts/edit-link';
 import './styles/index.scss';
-
-if (!!globalThis.window) {
-  document.body.addEventListener('click', function(e: any) {
-    if(e.target.classList.contains('edit-link-button')){
-      e.target.href = e.target.href + '?initialPath=' + document.location.pathname
-    }
-  }, true);
-}
 
 export default {
   ...DefaultTheme,

--- a/.vitepress/theme/scripts/edit-link.ts
+++ b/.vitepress/theme/scripts/edit-link.ts
@@ -1,0 +1,22 @@
+export {}; // required by TS --isolatedModules
+
+if (typeof document === 'object') {
+  document.body?.addEventListener('click', clickListener, true);
+}
+
+/**
+ * Add initialPath attribute to Web Publisher links,
+ * to render the correct page in the preview.
+ */
+function clickListener(event: MouseEvent) {
+  const link = event.target instanceof HTMLAnchorElement ? event.target : null;
+  if (
+    link &&
+    // only change edit link
+    link.classList.contains('edit-link-button') &&
+    // only change link once
+    !link.href.includes('initialPath=')
+  ) {
+    link.href = `${link.href}?initialPath=${document.location.pathname}`;
+  }
+}


### PR DESCRIPTION
# PR Description

This PR fixes the issue number: n.a.

### Summary of my changes and explanation of my decisions

- Moved the script we used to hack the URL of the "Edit this page" links from the theme's main config file to a dedicated script.
- Fixed TypeScript issues without using `(event: any)`.

### Self-check

Please check all that apply:

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my code or content update and edited it to the best of my abilities
- [x] I have commented my code, particularly in hard-to-understand areas; my comments are concise

### Contributors list

Would you like your contribution to be celebrated? Please check all that apply:

- [ ] I would like to be featured on the future contributors list in the README. If so, please tell us:
  - what name you'd like to be shown there?
  - we usually link github profile pic -- is that ok? If not, provide another url: 
  - we usually link your github profile but if you have a portfolio page, provide a link:

- [ ] I would like to get a shoutout in the next monthly updates post. If so, please provide your twitter handle (or we will link to your GitHub profile).

⚡️ ⚡️ ⚡️  Thank you for contributing to StackBlitz ⚡️ ⚡️ ⚡️ 
