### PR TITLE
Add support for Markdown footnotes (Pandoc-style)

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -1,4 +1,6 @@
 import dotenv from 'dotenv';
+/* @ts-expect-error */
+import mdFootnote from 'markdown-it-footnote';
 import { defineConfig, type HeadConfig } from 'vitepress';
 import * as data from '../docs/data';
 
@@ -84,6 +86,12 @@ export default defineConfig({
           items: data.enterpriseLinks,
         },
       ],
+    },
+  },
+
+  markdown: {
+    config: (md) => {
+      md.use(mdFootnote);
     },
   },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@types/node": "^16.11.7",
         "@vue/tsconfig": "^0.1.3",
         "dotenv": "^16.0.3",
+        "markdown-it-footnote": "^3.0.3",
         "prettier": "^2.7.1",
         "sass": "^1.55.0"
       }
@@ -1041,6 +1042,12 @@
         "sourcemap-codec": "^1.4.8"
       }
     },
+    "node_modules/markdown-it-footnote": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/markdown-it-footnote/-/markdown-it-footnote-3.0.3.tgz",
+      "integrity": "sha512-YZMSuCGVZAjzKMn+xqIco9d1cLGxbELHZ9do/TSYVzraooV8ypsppKNmUJ0fVH5ljkCInQAtFpm8Rb3eXSrt5w==",
+      "dev": true
+    },
     "node_modules/nanoid": {
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
@@ -2002,6 +2009,12 @@
       "requires": {
         "sourcemap-codec": "^1.4.8"
       }
+    },
+    "markdown-it-footnote": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/markdown-it-footnote/-/markdown-it-footnote-3.0.3.tgz",
+      "integrity": "sha512-YZMSuCGVZAjzKMn+xqIco9d1cLGxbELHZ9do/TSYVzraooV8ypsppKNmUJ0fVH5ljkCInQAtFpm8Rb3eXSrt5w==",
+      "dev": true
     },
     "nanoid": {
       "version": "3.3.4",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@types/node": "^16.11.7",
     "@vue/tsconfig": "^0.1.3",
     "dotenv": "^16.0.3",
+    "markdown-it-footnote": "^3.0.3",
     "prettier": "^2.7.1",
     "sass": "^1.55.0"
   },


### PR DESCRIPTION
# PR Description

This PR fixes the issue number: n.a.

### Summary of my changes and explanation of my decisions

Add support for Markdown footnotes, using the Pandoc footnotes syntax:

```markdown
Hello World[^1].

[^1]: In its most general sense, the term "world" refers to the totality of entities, to the whole of reality or to everything that is.
```

The footnote content can be placed at the end of an article, or inline in the content (in between paragraphs); it will always be rendered at the end.

### Self-check

Please check all that apply:

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my code or content update and edited it to the best of my abilities
- [ ] I have commented my code, particularly in hard-to-understand areas; my comments are concise

### Contributors list

Would you like your contribution to be celebrated? Please check all that apply:

- [ ] I would like to be featured on the future contributors list in the README. If so, please tell us:
  - what name you'd like to be shown there?
  - we usually link github profile pic -- is that ok? If not, provide another url: 
  - we usually link your github profile but if you have a portfolio page, provide a link:

- [ ] I would like to get a shoutout in the next monthly updates post. If so, please provide your twitter handle (or we will link to your GitHub profile).

⚡️ ⚡️ ⚡️  Thank you for contributing to StackBlitz ⚡️ ⚡️ ⚡️ 
