### PR TITLE
Update docs/codeflow/working-in-codeflow-ide.md

### DIFF
--- a/docs/codeflow/working-in-codeflow-ide.md
+++ b/docs/codeflow/working-in-codeflow-ide.md
@@ -64,7 +64,7 @@ Follow these steps:
 
 ## Reviewing a PR with Codeflow IDE 
 
-Let's look at [this suspicious PR](https://pr.new/stackblitz/docs/pull/40).
+Let's look at [this suspicious PR](https://github.com/stackblitz/docs/pull/40).
 
 Follow these steps:
 1. Open the link in a new tab. In the GitHub URL of the repository, replace "github.com" with "pr.new".

--- a/docs/codeflow/working-in-codeflow-ide.md
+++ b/docs/codeflow/working-in-codeflow-ide.md
@@ -67,7 +67,7 @@ Follow these steps:
 Let's look at [this suspicious PR](https://github.com/stackblitz/docs/pull/40).
 
 Follow these steps:
-1. Open the link in a new tab. In the GitHub URL of the repository, replace "github.com" with "pr.new".
+1. [Open the link](https://github.com/stackblitz/docs/pull/40) in a new tab. In the GitHub URL of the repository, replace "github.com" with "pr.new".
 2. Codeflow IDE will spin up in the "PR Review mode". Open the Preview by clicking on the popup notification in the bottom right corner.
 3. Compare suggested changes with the original file. You can also see the edits rendered in the Preview panel if you navigate to the edited page - in this case, the "What is StackBlitz" page.
 4. You can add comments by clicking on the "+" icons, read other comments, or start a review.


### PR DESCRIPTION
Submitted with [WebPublisher](https://pr.new)

The instructions (1) mention replacing "github.com" but the link already had done it. Either change the link, or change the steps.