### PR TITLE
fix: backwards-compatible case for URL query params

### DIFF
--- a/docs/guides/integration/embedding.md
+++ b/docs/guides/integration/embedding.md
@@ -51,13 +51,13 @@ You can use the following URL query parameters to customize the appearance and f
 | Parameter |               Value               |               Description               |
 |-----------|-----------------------------------|-----------------------------------------|
 |`ctl`| `0`/`1` | Prompts users to “click to load” the embed. |
-| `devToolsHeight` | `0` - `100` | Sets the height of [the console][ui_docs] in the editor preview. |
+| `devtoolsheight` | `0` - `100` | Sets the height of [the console][ui_docs] in the editor preview. |
 | `embed` |  `0`/`1` | Forces embed view regardless of screen size. |
 | `file` | file path | Specifies the default file to have open in the editor. |
-| `hideDevTools` |  `0`/`1` | Hides [the console][ui_docs] in the editor preview. |
+| `hidedevtools` |  `0`/`1` | Hides [the console][ui_docs] in the editor preview. |
 | `hideExplorer` |  `0`/`1` | Hides the [file explorer pane][ui_docs] in embed view. |
 | `hideNavigation` | `0`/`1` | Hides the preview’s URL bar. |
-| `initialPath` | URL path | Specifies the initial URL path (URI encoded) the preview should open. |
+| `initialpath` | URL path | Specifies the initial URL path (URI encoded) the preview should open. |
 | `showSidebar` | `0`/`1` | Shows the sidebar in embed view (large viewports only) |
 | `terminal` | string | Specifies the npm script to run on project load ([WebContainers-based projects][available_env_docs] only). |
 | `terminalHeight` | `0` - `100` | Sets the height of [the terminal][ui_docs]. |


### PR DESCRIPTION
# PR Description

This PR fixes the issue number: n.a.

### Summary of my changes and explanation of my decisions

This PR changes the case of documented URL query parameters to the case used by StackBlitz Enterprise Edition.

While `stackblitz.com` treats URL query parameters as case-insensitive, older StackBlitz EE deployments do not. Checking the code used in StackBlitz EE, it looks like the following parameters should be all lowercase:

- `devToolsHeight` -> `devtoolsheight`
- `hideDevTools` -> `hidedevtools`
- `initialPath` -> `initialpath`

Other parameters such as `hideExplorer` do use camel-case, and are documented with the correct case.

We just shipped a related fix to `@stackblitz/sdk` (no changes to the SDK docs required):
https://github.com/stackblitz/core/pull/2154

### Self-check

Please check all that apply:

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my code or content update and edited it to the best of my abilities
- [ ] I have commented my code, particularly in hard-to-understand areas; my comments are concise

### Contributors list

Would you like your contribution to be celebrated? Please check all that apply:

- [ ] I would like to be featured on the future contributors list in the README. If so, please tell us:
  - what name you'd like to be shown there?
  - we usually link github profile pic -- is that ok? If not, provide another url: 
  - we usually link your github profile but if you have a portfolio page, provide a link:

- [ ] I would like to get a shoutout in the next monthly updates post. If so, please provide your twitter handle (or we will link to your GitHub profile).

⚡️ ⚡️ ⚡️  Thank you for contributing to StackBlitz ⚡️ ⚡️ ⚡️ 
