### PR TITLE
Use YAML anchor labels for title 

### DIFF
--- a/docs/codeflow/codeflow-faq.md
+++ b/docs/codeflow/codeflow-faq.md
@@ -1,8 +1,8 @@
 ---
-title: Codeflow FAQ
+title: &title Codeflow FAQ
 description: 'This page addresses the frequently asked questions concerning: current features, security, planned features, pricing and access.'
 head:
-  - ['meta', {property: 'og:title', content: 'Codeflow FAQ'}]
+  - ['meta', {property: 'og:title', content: *title}] 
   - ['meta', {property: 'og:image', content: 'https://developer.stackblitz.com/img/og/codeflow-faq.png'}]
 ---
 

--- a/docs/codeflow/content-updates-with-web-publisher.md
+++ b/docs/codeflow/content-updates-with-web-publisher.md
@@ -1,8 +1,8 @@
 ---
-title: Content Updates with Web Publisher
+title: &title Content Updates with Web Publisher
 description: Content update? A small typo fix? No worries - Web Publisher makes this experience pleasant, including those of us who are not technical!
 head:
-  - ['meta', {property: 'og:title', content: 'Content Updates with Web Publisher'}]
+  - ['meta', {property: 'og:title', content: *title}] 
   - ['meta', {property: 'og:image', content: 'https://developer.stackblitz.com/img/og/content-updates-with-web_publisher.png'}]
 ---
 

--- a/docs/codeflow/integrating-codeflowapp-bot.md
+++ b/docs/codeflow/integrating-codeflowapp-bot.md
@@ -1,8 +1,8 @@
 ---
-title: Integrating CodeflowApp Bot
+title: &title Integrating CodeflowApp Bot
 description: This page covers integrating CodeflowApp Bot into your GitHub repositories.
 head:
-  - ['meta', {property: 'og:title', content: 'Integrating CodeflowApp Bot'}]
+  - ['meta', {property: 'og:title', content: *title}] 
   - ['meta', {property: 'og:image', content: 'https://developer.stackblitz.com/img/og/integrating-codeflowapp-bot.png'}]
 ---
 

--- a/docs/codeflow/integrating-web-publisher.md
+++ b/docs/codeflow/integrating-web-publisher.md
@@ -1,8 +1,8 @@
 ---
-title: Web Publisher docs integration
+title: &title Web Publisher docs integration
 description: This page covers integrating Web Publisher into your docs to lower the barrier for contributing to documentations.
 head:
-  - ['meta', {property: 'og:title', content: 'Web Publisher docs integration'}]
+  - ['meta', {property: 'og:title', content: *title}] 
   - ['meta', {property: 'og:image', content: 'https://developer.stackblitz.com/img/og/integrating-web_publisher.png'}]
 ---
 

--- a/docs/codeflow/using-pr-new.md
+++ b/docs/codeflow/using-pr-new.md
@@ -1,8 +1,8 @@
 ---
-title: Using pr.new
+title: &title Using pr.new
 description: This page covers using pr.new to open, view, and contribute to any project through our Codeflow IDE or Web Publisher.
 head:
-  - ['meta', {property: 'og:title', content: 'Using pr.new'}]
+  - ['meta', {property: 'og:title', content: *title}] 
   - ['meta', {property: 'og:image', content: 'https://developer.stackblitz.com/img/og/using-pr_new.png'}]
 ---
 

--- a/docs/codeflow/what-is-codeflow.md
+++ b/docs/codeflow/what-is-codeflow.md
@@ -1,8 +1,8 @@
 ---
-title: What is Codeflow?
+title: &title What is Codeflow?
 description: Codeflow is a one-click integration with GitHub for seamless coding workflows.
 head:
-  - ['meta', {property: 'og:title', content: 'What is Codeflow?'}]
+  - ['meta', {property: 'og:title', content: *title}] 
   - ['meta', {property: 'og:image', content: 'https://developer.stackblitz.com/img/og/what-is-codeflow.png'}]
 ---
 

--- a/docs/codeflow/working-in-codeflow-ide.md
+++ b/docs/codeflow/working-in-codeflow-ide.md
@@ -1,8 +1,8 @@
 ---
-title: Working in Codeflow IDE
+title: &title Working in Codeflow IDE
 description: Are you ready to make Codeflow your workflow? This page covers what to expect when using Codeflow IDE.
 head:
-  - ['meta', {property: 'og:title', content: 'Working in Codeflow IDE'}]
+  - ['meta', {property: 'og:title', content: *title}] 
   - ['meta', {property: 'og:image', content: 'https://developer.stackblitz.com/img/og/working-in-codeflow-ide.png'}]
 ---
 

--- a/docs/enterprise/adfs-sso.md
+++ b/docs/enterprise/adfs-sso.md
@@ -1,8 +1,8 @@
 ---
-title: Setting up SSO with ADFS
+title: &title Setting up SSO with ADFS
 description: StackBlitz is excited to offer SAML-based Single Sign-on (SSO) to organizations using Active Directory Federation Service (ADFS).
 head:
-  - ['meta', {property: 'og:title', content: 'Setting up SSO with ADFS'}]
+  - ['meta', {property: 'og:title', content: *title}] 
   - ['meta', {property: 'og:image', content: 'https://developer.stackblitz.com/img/og/enterprise-setting-up-sso-with-adfs.png'}]
 ---
 

--- a/docs/enterprise/configuring-dns.md
+++ b/docs/enterprise/configuring-dns.md
@@ -1,8 +1,8 @@
 ---
-title: Configuring DNS & TLS
+title: &title Configuring DNS & TLS
 description: Based off the root DNS zone set in EE Site Configuration (for instance, `stackblitz.example.com`), set the following DNS `A` records to point at your instance's IP.
 head:
-  - ['meta', {property: 'og:title', content: 'Configuring DNS & TLS'}]
+  - ['meta', {property: 'og:title', content: *title}] 
   - ['meta', {property: 'og:image', content: 'https://developer.stackblitz.com/img/og/enterprise-configuring-dns-tls.png'}]
 ---
 

--- a/docs/enterprise/configuring-firewall-rules.md
+++ b/docs/enterprise/configuring-firewall-rules.md
@@ -1,8 +1,8 @@
 ---
-title: Configuring Firewall Rules
+title: &title Configuring Firewall Rules
 description: Depending on the network configuration, some installs need to have a complete list of expected outbound network traffic (in order to open ports in firewalls) and allowed hosts and IP addresses for outbound connectivity.
 head:
-  - ['meta', {property: 'og:title', content: 'Configuring Firewall Rules'}]
+  - ['meta', {property: 'og:title', content: *title}] 
   - ['meta', {property: 'og:image', content: 'https://developer.stackblitz.com/img/og/enterprise-configuring-firewall-rules.png'}]
 ---
 

--- a/docs/enterprise/data-migration.md
+++ b/docs/enterprise/data-migration.md
@@ -1,9 +1,9 @@
 ---
-title: Migrating StackBlitz Data
+title: &title Migrating StackBlitz Data
 sidebar_label: Data Migration
 description: By default, StackBlitz Enterprise Edition (EE) will deploy a basic PostgreSQL container instance for persisting user and project data. This provides trial users with the fastest possible deployment experience but is not well-suited for production use.
 head:
-  - ['meta', {property: 'og:title', content: 'Migrating StackBlitz Data'}]
+  - ['meta', {property: 'og:title', content: *title}] 
   - ['meta', {property: 'og:image', content: 'https://developer.stackblitz.com/img/og/enterprise-data-migration.png'}]
 ---
 

--- a/docs/enterprise/installation/administrator-guide.md
+++ b/docs/enterprise/installation/administrator-guide.md
@@ -1,8 +1,8 @@
 ---
-title: Administrator Guide
+title: &title Administrator Guide
 description: This document covers in-depth custom installation and cluster operations.
 head:
-  - ['meta', {property: 'og:title', content: 'Administrator Guide'}]
+  - ['meta', {property: 'og:title', content: *title}] 
   - ['meta', {property: 'og:image', content: 'https://developer.stackblitz.com/img/og/enterprise-installation-administration-guide.png'}]
 ---
 

--- a/docs/enterprise/installation/air-gapped-installs.md
+++ b/docs/enterprise/installation/air-gapped-installs.md
@@ -1,8 +1,8 @@
 ---
-title: Air Gapped Installs
+title: &title Air Gapped Installs
 description: StackBlitz supports air gapped installations for networks that have restricted outbound network access.
 head:
-  - ['meta', {property: 'og:title', content: 'Air Gapped Installs'}]
+  - ['meta', {property: 'og:title', content: *title}] 
   - ['meta', {property: 'og:image', content: 'https://developer.stackblitz.com/img/og/enterprise-installation-air-gapped-installs.png'}]
 ---
 

--- a/docs/enterprise/installation/quickstart-existing-cluster.md
+++ b/docs/enterprise/installation/quickstart-existing-cluster.md
@@ -1,8 +1,8 @@
 ---
-title: Quickstart (Existing Cluster)
+title: &title Quickstart (Existing Cluster)
 description: StackBlitz Enterprise is a Kubernetes application. You can follow these instructions to install the software on an existing Kubernetes cluster.
 head:
-  - ['meta', {property: 'og:title', content: 'Quickstart (Existing Cluster)'}]
+  - ['meta', {property: 'og:title', content: *title}] 
   - ['meta', {property: 'og:image', content: 'https://developer.stackblitz.com/img/og/enterprise-installation-quickstart-on-existing-cluster.png'}]
 ---
 

--- a/docs/enterprise/installation/quickstart-gcp.md
+++ b/docs/enterprise/installation/quickstart-gcp.md
@@ -1,8 +1,8 @@
 ---
-title: Quickstart on GCP (Non-GKE)
+title: &title Quickstart on GCP (Non-GKE)
 description: StackBlitz Enterprise is a Kubernetes application. You can install the software on an existing cluster or use our installer that has an embedded, production-ready Kubernetes distribution packaged with it.
 head:
-  - ['meta', {property: 'og:title', content: 'Quickstart on GCP (Non-GKE)'}]
+  - ['meta', {property: 'og:title', content: *title}] 
   - ['meta', {property: 'og:image', content: 'https://developer.stackblitz.com/img/og/enterprise-installation-quickstart-on-gcp.png'}]
 ---
 

--- a/docs/enterprise/installation/quickstart.md
+++ b/docs/enterprise/installation/quickstart.md
@@ -1,8 +1,8 @@
 ---
-title: Quickstart on Bare Metal
+title: &title Quickstart on Bare Metal
 description: StackBlitz Enterprise is a Kubernetes application. You can install the software on an existing cluster or use our installer that has an embedded, production-ready Kubernetes distribution packaged with it.
 head:
-  - ['meta', {property: 'og:title', content: 'Quickstart on Bare Metal'}]
+  - ['meta', {property: 'og:title', content: *title}] 
   - ['meta', {property: 'og:image', content: 'https://developer.stackblitz.com/img/og/enterprise-installation-quickstart-on-bare-metal.png'}]
 ---
 

--- a/docs/enterprise/log-aggregation.md
+++ b/docs/enterprise/log-aggregation.md
@@ -1,9 +1,9 @@
 ---
-title: Aggregating Logs
+title: &title Aggregating Logs
 sidebar_label: Aggregating Logs
 description: StackBlitz EE is built on Kubernetes and PostgreSQL, which makes shipping your StackBlitz EE logs to your existing logging infrastructure relatively simple.
 head:
-  - ['meta', {property: 'og:title', content: 'Aggregating Logs'}]
+  - ['meta', {property: 'og:title', content: *title}] 
   - ['meta', {property: 'og:image', content: 'https://developer.stackblitz.com/img/og/enterprise-aggregating-logs.png'}]
 ---
 

--- a/docs/enterprise/npm.md
+++ b/docs/enterprise/npm.md
@@ -1,8 +1,8 @@
 ---
-title: Connect npm registry
+title: &title Connect npm registry
 description: StackBlitz is excited to offer custom npm registry support to organizations using StackBlitz Enterprise Edition (EE).
 head:
-  - ['meta', {property: 'og:title', content: 'Connect npm registry'}]
+  - ['meta', {property: 'og:title', content: *title}] 
   - ['meta', {property: 'og:image', content: 'https://developer.stackblitz.com/img/og/enterprise-connect-npm-registry.png'}]
 ---
 

--- a/docs/enterprise/okta-sso.md
+++ b/docs/enterprise/okta-sso.md
@@ -1,8 +1,8 @@
 ---
-title: Setting up SSO with Okta
+title: &title Setting up SSO with Okta
 description: StackBlitz is excited to offer SAML-based Single Sign-on (SSO) to organizations using StackBlitz Enterprise Edition (EE).
 head:
-  - ['meta', {property: 'og:title', content: 'Setting up SSO with Okta'}]
+  - ['meta', {property: 'og:title', content: *title}] 
   - ['meta', {property: 'og:image', content: 'https://developer.stackblitz.com/img/og/enterprise-setting-up-sso-with-okta.png'}]
 ---
 

--- a/docs/enterprise/overview.md
+++ b/docs/enterprise/overview.md
@@ -1,9 +1,9 @@
 ---
-title: StackBlitz Enterprise Edition (EE)
+title: &title StackBlitz Enterprise Edition (EE)
 description: Welcome! Let's get started setting up StackBlitz Enterprise Edition.
 sidebar_label: Overview
 head:
-  - ['meta', {property: 'og:title', content: 'StackBlitz Enterprise Edition (EE)'}]
+  - ['meta', {property: 'og:title', content: *title}] 
   - ['meta', {property: 'og:image', content: 'https://developer.stackblitz.com/img/og/enterprise-overview.png'}]
 ---
 

--- a/docs/enterprise/sso.md
+++ b/docs/enterprise/sso.md
@@ -1,8 +1,8 @@
 ---
-title: Setting up SSO
+title: &title Setting up SSO
 description: StackBlitz is excited to offer SAML-based Single Sign-on (SSO) to organizations using StackBlitz Enterprise Edition (EE).
 head:
-  - ['meta', {property: 'og:title', content: 'Setting up SSO'}]
+  - ['meta', {property: 'og:title', content: *title}] 
   - ['meta', {property: 'og:image', content: 'https://developer.stackblitz.com/img/og/enterprise-setting-up-sso.png'}]
 ---
 

--- a/docs/enterprise/starter-projects.md
+++ b/docs/enterprise/starter-projects.md
@@ -1,8 +1,8 @@
 ---
-title: Starter Projects
+title: &title Starter Projects
 description: When working on a team, you'll likely want to customize the default starter projects that show up on the StackBlitz dashboard. Sharing common templates that are always one-click away enables seamless prototyping, debugging, and experimentation with your company's design system & internal libraries.
 head:
-  - ['meta', {property: 'og:title', content: 'Starter Projects'}]
+  - ['meta', {property: 'og:title', content: *title}] 
   - ['meta', {property: 'og:image', content: 'https://developer.stackblitz.com/img/og/enterprise-starter-projects.png'}]
 ---
 

--- a/docs/enterprise/user-management.md
+++ b/docs/enterprise/user-management.md
@@ -1,8 +1,8 @@
 ---
-title: User Management
+title: &title User Management
 description: After successful installation, StackBlitz EE comes with a single admin account that can be used for site administration. However, you'll likely want to grant admin access to at least one SSO-based account if you plan on using custom starter projects.
 head:
-  - ['meta', {property: 'og:title', content: 'User Management'}]
+  - ['meta', {property: 'og:title', content: *title}] 
   - ['meta', {property: 'og:image', content: 'https://developer.stackblitz.com/img/og/enterprise-user-management.png'}]
 ---
 

--- a/docs/guides/integration/bug-reproductions.md
+++ b/docs/guides/integration/bug-reproductions.md
@@ -1,8 +1,8 @@
 ---
-title: Bug reproductions
+title: &title Bug reproductions
 description: A well-described issue is immensely helpful when developing a software product, and a minimal reproduction is one of the most useful part of the conversation.
 head:
-  - ['meta', {property: 'og:title', content: 'Bug reproductions'}]
+  - ['meta', {property: 'og:title', content: *title}] 
   - ['meta', {property: 'og:image', content: 'https://developer.stackblitz.com/img/og/bug-reproductions.png'}]
 ---
 

--- a/docs/guides/integration/create-with-sdk.md
+++ b/docs/guides/integration/create-with-sdk.md
@@ -1,8 +1,8 @@
 ---
-title: Creating projects with the SDK
+title: &title Creating projects with the SDK
 description: This page will guide you through the SDK setup and available options.
 head:
-  - ['meta', {property: 'og:title', content: 'Creating projects with the SDK'}]
+  - ['meta', {property: 'og:title', content: *title}] 
   - ['meta', {property: 'og:image', content: 'https://developer.stackblitz.com/img/og/creating-projects-with-the-sdk.png'}]
 ---
 
@@ -66,7 +66,7 @@ StackBlitzSDK.openProject(
       'index.js': `alert('Woohoo! We can start documenting!')`,
     },
     template: 'javascript',
-    title: `My First Docs!`,
+    title: &title `My First Docs!`,
     description: `This is an example of my first doc!`,
   },
 
@@ -142,7 +142,7 @@ Now that you have the content of your project defined, it is useful to provide s
 
 ```js
 {
-  title: `My First Docs!`,
+  title: &title `My First Docs!`,
   description: `This is an example of my first doc!`
 }
 ```

--- a/docs/guides/integration/create-with-sdk.md
+++ b/docs/guides/integration/create-with-sdk.md
@@ -66,7 +66,7 @@ StackBlitzSDK.openProject(
       'index.js': `alert('Woohoo! We can start documenting!')`,
     },
     template: 'javascript',
-    title: &title `My First Docs!`,
+    title: `My First Docs!`,
     description: `This is an example of my first doc!`,
   },
 
@@ -142,7 +142,7 @@ Now that you have the content of your project defined, it is useful to provide s
 
 ```js
 {
-  title: &title `My First Docs!`,
+  title: `My First Docs!`,
   description: `This is an example of my first doc!`
 }
 ```

--- a/docs/guides/integration/embedding.md
+++ b/docs/guides/integration/embedding.md
@@ -1,8 +1,8 @@
 ---
-title: Embedding projects
+title: &title Embedding projects
 description: Embedding is one way to display a StackBlitz editor in a documentation page, a blog post, or any other page. This page covers manual embedding in iframes. 
 head:
-  - ['meta', {property: 'og:title', content: 'Embedding projects'}]
+  - ['meta', {property: 'og:title', content: *title}] 
   - ['meta', {property: 'og:image', content: 'https://developer.stackblitz.com/img/og/embedding-projects.png'}]
 ---
 

--- a/docs/guides/integration/open-from-github.md
+++ b/docs/guides/integration/open-from-github.md
@@ -1,8 +1,8 @@
 ---
-title: Launching projects from GitHub
+title: &title Launching projects from GitHub
 description: When providing an example for your users to open, there are several things to consider.
 head:
-  - ['meta', {property: 'og:title', content: 'Launching projects from GitHub'}]
+  - ['meta', {property: 'og:title', content: *title}] 
   - ['meta', {property: 'og:image', content: 'https://developer.stackblitz.com/img/og/launching-projects-from-github.png'}]
 ---
 

--- a/docs/guides/user-guide/available-environments.md
+++ b/docs/guides/user-guide/available-environments.md
@@ -1,8 +1,8 @@
 ---
-title: Available environments
+title: &title Available environments
 description: "There are two kinds of environments that run projects in StackBlitz: EngineBlock and WebContainers. Each project in StackBlitz is tied to one or the other."
 head:
-  - ['meta', {property: 'og:title', content: 'Available environments'}]
+  - ['meta', {property: 'og:title', content: *title}] 
   - ['meta', {property: 'og:image', content: 'https://developer.stackblitz.com/img/og/available-environments.png'}]
 ---
 

--- a/docs/guides/user-guide/getting-started.md
+++ b/docs/guides/user-guide/getting-started.md
@@ -1,8 +1,8 @@
 ---
-title: Getting started
+title: &title Getting started
 description: This page outlines how you can start using our StackBlitz editor.
 head:
-  - ['meta', {property: 'og:title', content: 'Getting started'}]
+  - ['meta', {property: 'og:title', content: *title}] 
   - ['meta', {property: 'og:image', content: 'https://developer.stackblitz.com/img/og/getting-started.png'}]
 ---
 

--- a/docs/guides/user-guide/ide-whats-on-your-screen.md
+++ b/docs/guides/user-guide/ide-whats-on-your-screen.md
@@ -1,8 +1,8 @@
 ---
-title: "IDE: what’s on your screen"
+title: &title "IDE: what’s on your screen"
 description: This page provides an overview of the terms we use to describe each of the pieces of the UI available to you in StackBlitz projects.
 head:
-  - ['meta', {property: 'og:title', content: 'IDE: what’s on your screen'}]
+  - ['meta', {property: 'og:title', content: *title}] 
   - ['meta', {property: 'og:image', content: 'https://developer.stackblitz.com/img/og/ide-whats-on-your-screen.png'}]
 ---
 

--- a/docs/guides/user-guide/importing-projects.md
+++ b/docs/guides/user-guide/importing-projects.md
@@ -1,8 +1,8 @@
 ---
-title: Importing projects
+title: &title Importing projects
 description: This page outlines how you can import projects to StackBlitz.
 head:
-  - ['meta', {property: 'og:title', content: 'Importing projects'}]
+  - ['meta', {property: 'og:title', content: *title}] 
   - ['meta', {property: 'og:image', content: 'https://developer.stackblitz.com/img/og/importing-projects.png'}]
 ---
 

--- a/docs/guides/user-guide/keyboard-shortcuts.md
+++ b/docs/guides/user-guide/keyboard-shortcuts.md
@@ -1,8 +1,8 @@
 ---
-title: Keyboard shortcuts
+title: &title Keyboard shortcuts
 description: A “keyboard shortcut” or “keybinding” is combination of keys on your keyboard which allows you to perform  common actions such as saving a file, modifying the view, or copying a line of code. In the StackBlitz editor this set of shortcuts is predefined and, currently, non-customizable.
 head:
-  - ['meta', {property: 'og:title', content: 'Keyboard shortcuts'}]
+  - ['meta', {property: 'og:title', content: *title}] 
   - ['meta', {property: 'og:image', content: 'https://developer.stackblitz.com/img/og/keyboard-shortcuts.png'}]
 ---
 

--- a/docs/guides/user-guide/starter-projects.md
+++ b/docs/guides/user-guide/starter-projects.md
@@ -1,8 +1,8 @@
 ---
-title: Starter projects
+title: &title Starter projects
 description: Starter projects are online playgrounds, typically built by the core team of a given project and run on StackBlitz.
 head:
-  - ['meta', {property: 'og:title', content: 'Starter projects'}]
+  - ['meta', {property: 'og:title', content: *title}] 
   - ['meta', {property: 'og:image', content: 'https://developer.stackblitz.com/img/og/starter-projects.png'}]
 ---
 

--- a/docs/guides/user-guide/what-is-stackblitz.md
+++ b/docs/guides/user-guide/what-is-stackblitz.md
@@ -1,8 +1,8 @@
 ---
-title: What is StackBlitz?
+title: &title What is StackBlitz?
 description: StackBlitz is an instant fullstack web IDE for the JavaScript ecosystem. It's powered by WebContainers, the first WebAssembly-based operating system which boots Node.js environment in milliseconds, securely within your browser tab.
 head:
-  - ['meta', {property: 'og:title', content: 'What is StackBlitz?'}]
+  - ['meta', {property: 'og:title', content: *title}] 
   - ['meta', {property: 'og:image', content: 'https://developer.stackblitz.com/img/og/what-is-stackblitz.png'}]
 ---
 

--- a/docs/platform/api/javascript-sdk-dependencies.md
+++ b/docs/platform/api/javascript-sdk-dependencies.md
@@ -1,8 +1,8 @@
 ---
-title: Managing dependencies with the SDK
+title: &title Managing dependencies with the SDK
 description: When creating new projects with the `sdk.openProject` and `sdk.embedProject` methods, you can specify which npm dependencies should be installed on startup.
 head:
-  - ['meta', {property: 'og:title', content: 'Managing dependencies with the SDK'}]
+  - ['meta', {property: 'og:title', content: *title}] 
   - ['meta', {property: 'og:image', content: 'https://developer.stackblitz.com/img/og/sdk-managing-dependencies.png'}]
 ---
 
@@ -37,7 +37,7 @@ const packageJson = `{
 }`;
 
 const project = {
-  title: 'Node serve demo',
+  title: &title 'Node serve demo',
   description: 'Node.js server demo using the "serve" package',
   template: 'node',
   files: {
@@ -87,7 +87,7 @@ const PACKAGE_JSON = {
 };
 
 const project = {
-  title: 'My cool project',
+  title: &title 'My cool project',
   description: 'Example animation project',
   template: 'javascript',
   // REQUIRED: specify dependencies

--- a/docs/platform/api/javascript-sdk-dependencies.md
+++ b/docs/platform/api/javascript-sdk-dependencies.md
@@ -37,7 +37,7 @@ const packageJson = `{
 }`;
 
 const project = {
-  title: &title 'Node serve demo',
+  title: 'Node serve demo',
   description: 'Node.js server demo using the "serve" package',
   template: 'node',
   files: {
@@ -87,7 +87,7 @@ const PACKAGE_JSON = {
 };
 
 const project = {
-  title: &title 'My cool project',
+  title: 'My cool project',
   description: 'Example animation project',
   template: 'javascript',
   // REQUIRED: specify dependencies

--- a/docs/platform/api/javascript-sdk-options.md
+++ b/docs/platform/api/javascript-sdk-options.md
@@ -1,8 +1,8 @@
 ---
-title: SDK Options Reference
+title: &title SDK Options Reference
 description: Modify your StackBlitz project with SDK options.
 head:
-  - ['meta', {property: 'og:title', content: 'SDK Options Reference'}]
+  - ['meta', {property: og:title, content: *title}] 
   - ['meta', {property: 'og:image', content: 'https://developer.stackblitz.com/img/og/sdk-options-reference.png'}]
 ---
 

--- a/docs/platform/api/javascript-sdk-options.md
+++ b/docs/platform/api/javascript-sdk-options.md
@@ -2,7 +2,7 @@
 title: &title SDK Options Reference
 description: Modify your StackBlitz project with SDK options.
 head:
-  - ['meta', {property: og:title, content: *title}] 
+  - ['meta', {property: 'og:title', content: *title}] 
   - ['meta', {property: 'og:image', content: 'https://developer.stackblitz.com/img/og/sdk-options-reference.png'}]
 ---
 

--- a/docs/platform/api/javascript-sdk-vm.md
+++ b/docs/platform/api/javascript-sdk-vm.md
@@ -1,8 +1,8 @@
 ---
-title: Controlling embeds with the SDK’s VM interface
+title: &title Controlling embeds with the SDK’s VM interface
 description: All of the embed methods of the StackBlitz JS SDK automatically connect to the embedded StackBlitz VM, giving you programmatic access to the embedded project.
 head:
-  - ['meta', {property: 'og:title', content: 'Controlling embeds with the SDK’s VM interface'}]
+  - ['meta', {property: 'og:title', content: *title}] 
   - ['meta', {property: 'og:image', content: 'https://developer.stackblitz.com/img/og/sdk-controlling-embeds.png'}]
 ---
 

--- a/docs/platform/api/javascript-sdk.md
+++ b/docs/platform/api/javascript-sdk.md
@@ -1,8 +1,8 @@
 ---
-title: JavaScript SDK
+title: &title JavaScript SDK
 description: The StackBlitz JavaScript SDK lets you programmatically create StackBlitz projects to be opened in a new window or embedded in your docs, example pages, or blog posts. 
 head:
-  - ['meta', {property: 'og:title', content: 'JavaScript SDK'}]
+  - ['meta', {property: 'og:title', content: *title}] 
   - ['meta', {property: 'og:image', content: 'https://developer.stackblitz.com/img/og/javascript-sdk.png'}]
 ---
 
@@ -180,7 +180,7 @@ Example:
 ```js
 sdk.openProject(
   {
-    title: 'JS Starter',
+    title: &title 'JS Starter',
     description: 'Blank starter project for building ES6 apps.',
     template: 'javascript',
     files: {
@@ -220,7 +220,7 @@ Example:
 sdk.embedProject(
   'embed',
   {
-    title: 'Node Starter',
+    title: &title 'Node Starter',
     description: 'A basic Node.js project',
     template: 'node',
     files: {

--- a/docs/platform/api/javascript-sdk.md
+++ b/docs/platform/api/javascript-sdk.md
@@ -180,7 +180,7 @@ Example:
 ```js
 sdk.openProject(
   {
-    title: &title 'JS Starter',
+    title: 'JS Starter',
     description: 'Blank starter project for building ES6 apps.',
     template: 'javascript',
     files: {
@@ -220,7 +220,7 @@ Example:
 sdk.embedProject(
   'embed',
   {
-    title: &title 'Node Starter',
+    title: 'Node Starter',
     description: 'A basic Node.js project',
     template: 'node',
     files: {

--- a/docs/platform/api/post-api.md
+++ b/docs/platform/api/post-api.md
@@ -1,8 +1,8 @@
 ---
-title: POST API
+title: &title POST API
 description: Create new projects by POSTing the desired project data from a form. This method is useful when you don't or can't use our JavaScript SDK.
 head:
-  - ['meta', {property: 'og:title', content: 'POST API'}]
+  - ['meta', {property: 'og:title', content: *title}] 
   - ['meta', {property: 'og:image', content: 'https://developer.stackblitz.com/img/og/post-api.png'}]
 ---
 

--- a/docs/platform/api/webcontainer-api.md
+++ b/docs/platform/api/webcontainer-api.md
@@ -1,8 +1,8 @@
 ---
-title: WebContainer API
+title: &title WebContainer API
 description: WebContainer API allows for running WebContainers headlessly. It is currently in the pre-release alpha stage and accessed by invite only.
 head:
-  - ['meta', {property: 'og:title', content: 'WebContainer API'}]
+  - ['meta', {property: 'og:title', content: *title}] 
   - ['meta', {property: 'og:image', content: 'https://developer.stackblitz.com/img/og/webcontainer-api.png'}]
 ---
 

--- a/docs/platform/webcontainers/browser-config-brave.md
+++ b/docs/platform/webcontainers/browser-config-brave.md
@@ -1,8 +1,8 @@
 ---
-title: Running in Brave
+title: &title Running in Brave
 description: WebContainers work in Brave almost out of the box. However, it might require a small configuration change.
 head:
-  - ['meta', {property: 'og:title', content: 'Running in Brave'}]
+  - ['meta', {property: 'og:title', content: *title}] 
   - ['meta', {property: 'og:image', content: 'https://developer.stackblitz.com/img/og/webcontainer-running-in-brave.png'}]
 ---
 

--- a/docs/platform/webcontainers/browser-config.md
+++ b/docs/platform/webcontainers/browser-config.md
@@ -1,8 +1,8 @@
 ---
-title: Configuring your browser to run WebContainers
+title: &title Configuring your browser to run WebContainers
 description: Most of the time, WebContainers run fine in supported browsers. However, some browsers have default content restrictions, like third-party cookie and Service Worker blocking, that can prevent StackBlitz WebContainers from running properly. 
 head:
-  - ['meta', {property: 'og:title', content: 'Configuring your browser to run WebContainers'}]
+  - ['meta', {property: 'og:title', content: *title}] 
   - ['meta', {property: 'og:image', content: 'https://developer.stackblitz.com/img/og/webcontainer-browser-configuration.png'}]
 ---
 

--- a/docs/platform/webcontainers/browser-support.md
+++ b/docs/platform/webcontainers/browser-support.md
@@ -1,8 +1,8 @@
 ---
-title: WebContainers Browser Support
+title: &title WebContainers Browser Support
 description: For WebContainers, we support desktop Chromium-based browsers out of the box, and Firefox in alpha state.
 head:
-  - ['meta', {property: 'og:title', content: 'WebContainers Browser Support'}]
+  - ['meta', {property: 'og:title', content: *title}] 
   - ['meta', {property: 'og:image', content: 'https://developer.stackblitz.com/img/og/webcontainer-browser-support.png'}]
 ---
 

--- a/docs/platform/webcontainers/project-config.md
+++ b/docs/platform/webcontainers/project-config.md
@@ -1,8 +1,8 @@
 ---
-title: Project configuration
+title: &title Project configuration
 description: "Projects based on WebContainers can be configured in the following ways: 1. with project files (`package.json` or `.stackblitzrc`), 2. with URL parameters#with-url-parameters."
 head:
-  - ['meta', {property: 'og:title', content: 'Project configuration'}]
+  - ['meta', {property: 'og:title', content: *title}] 
   - ['meta', {property: 'og:image', content: 'https://developer.stackblitz.com/img/og/webcontainer-project-configuration.png'}]
 ---
 

--- a/docs/platform/webcontainers/troubleshooting-webcontainers.md
+++ b/docs/platform/webcontainers/troubleshooting-webcontainers.md
@@ -1,8 +1,8 @@
 ---
-title: Troubleshooting WebContainers
+title: &title Troubleshooting WebContainers
 description: This page helps you troubleshoot issues with WebContainers.
 head:
-  - ['meta', {property: 'og:title', content: 'Troubleshooting WebContainers'}]
+  - ['meta', {property: 'og:title', content: *title}] 
   - ['meta', {property: 'og:image', content: 'https://developer.stackblitz.com/img/og/webcontainer-troubleshooting.png'}]
 ---
 

--- a/docs/platform/webcontainers/turbo-package-manager.md
+++ b/docs/platform/webcontainers/turbo-package-manager.md
@@ -1,8 +1,8 @@
 ---
-title: Turbo Package Manager
+title: &title Turbo Package Manager
 description: WebContainers-based projects use Turbo as package manager. Turbo is our custom npm client and it works similarly to `npm` and `yarn`. 
 head:
-  - ['meta', {property: 'og:title', content: 'Turbo Package Manager'}]
+  - ['meta', {property: 'og:title', content: *title}] 
   - ['meta', {property: 'og:image', content: 'https://developer.stackblitz.com/img/og/webcontainer-turbo-package-manager.png'}]
 ---
 


### PR DESCRIPTION
# PR Description

This PR fixes the issue number: SBPF-3223


### Summary of my changes and explanation of my decisions

- Use YAML anchors to not repeat title in `og:title`.  You use the anchor `&`  to define and you can use it later with the reference anchor `*` (didn't know!) 

### Self-check

Please check all that apply:

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my code or content update and edited it to the best of my abilities
- [x] I have commented my code, particularly in hard-to-understand areas; my comments are concise

### Contributors list

Would you like your contribution to be celebrated? Please check all that apply:

- [ ] I would like to be featured on the future contributors list in the README. If so, please tell us:
  - what name you'd like to be shown there?
  - we usually link github profile pic -- is that ok? If not, provide another url: 
  - we usually link your github profile but if you have a portfolio page, provide a link:

- [ ] I would like to get a shoutout in the next monthly updates post. If so, please provide your twitter handle (or we will link to your GitHub profile).

⚡️ ⚡️ ⚡️  Thank you for contributing to StackBlitz ⚡️ ⚡️ ⚡️ 
