### PR TITLE
Florens/start script query param

### DIFF
--- a/docs/guides/integration/embedding.md
+++ b/docs/guides/integration/embedding.md
@@ -63,7 +63,7 @@ You can use the following URL query parameters to customize the appearance and f
 | `hideNavigation` | `0`/`1` | Hides the preview’s URL bar. |
 | `initialpath` | URL path | Specifies the initial URL path (URI encoded) the preview should open. |
 | `showSidebar` | `0`/`1` | Shows the sidebar in embed view (large viewports only) |
-| `terminal` | string | Specifies the npm script to run on project load ([WebContainers-based projects][available_env_docs] only). |
+| `startScript` | string | Specifies the npm script to run on project load ([WebContainers-based projects][available_env_docs] only). |
 | `terminalHeight` | `0` - `100` | Sets the height of [the terminal][ui_docs]. |
 | `theme` | `light` - `dark` | Sets the color theme of the editor UI. |
 | `view` | `editor` - `preview` | Specifies which view to open by default. |

--- a/docs/guides/integration/open-from-github.md
+++ b/docs/guides/integration/open-from-github.md
@@ -111,26 +111,30 @@ https://stackblitz.com/github/vercel/next.js/tree/canary/examples/hello-world?ti
 
 ### Launching a script on project load
 
-Usually, in your project’s `package.json` file there is a script that you would instruct your users to run in order to, for instance, launch a development server. Suppose your `package.json` includes such `dev` script:
+StackBlitz will look in your project’s `package.json` file for a [npm script](https://docs.npmjs.com/cli/v8/using-npm/scripts) to run on project load. By default, it looks for a script named `"dev"` first, then for a script named `"start"`.
+
+We recommend setting up your project’s `package.json` to use the `"dev"` or `"start"` script to launch a development server:
 
 ```json
 {
 	"scripts": {
+    "build": "vite build",
 		"dev": "vite"
 	}
 }
 ```
 
-In order to run an [npm script](https://docs.npmjs.com/cli/v8/using-npm/scripts) automatically when the editor opens, you can either:
+If you want to run a different script or command, you can use one of the following methods:
 
-- provide the `terminal` query parameter:
+- When linking to your project on StackBlitz, use the `startScript` query parameter:
   ```
-  ?terminal=dev
+  ?startScript=build
   ```
-- create the `.stackblitzrc` file with the `startCommand` option:
+
+- Or create a `.stackblitzrc` file with the `startCommand` option:
   ```json
   {
-    "startCommand": "npm run dev"
+    "startCommand": "npm run build"
   }
   ```
 

--- a/docs/guides/user-guide/importing-projects.md
+++ b/docs/guides/user-guide/importing-projects.md
@@ -43,14 +43,14 @@ Oftentimes, the first thing you do when opening a project is to launch a command
 
 Usually, these kinds of commands exist in the `scripts` section of your project's `package.json` file and you would manually type `npm run dev` to execute them.
 
-Using StackBlitz, you can provide an [npm script](https://docs.npmjs.com/cli/v8/using-npm/scripts) to run automatically when the editor opens with the `terminal` query parameter:
+Using StackBlitz, you can provide an [npm script](https://docs.npmjs.com/cli/v8/using-npm/scripts) to run automatically when the editor opens with the `startScript` query parameter:
 
-`stackblitz.com/fork/github/{gh_username}/{repo_name}?terminal={npm_script_name}`
+`stackblitz.com/fork/github/{gh_username}/{repo_name}?startScript={npm_script_name}`
 
 :::tip Example
 The following URL will open the `vitesse` repository of the `antfu` user, install the npm dependencies, and run `npm run dev` command in the terminal:
 
-[stackblitz.com/github/antfu/vitesse?terminal=dev](http://www.stackblitz.com/github/antfu/vitesse?terminal=dev)
+[stackblitz.com/github/antfu/vitesse?startScript=dev](https://stackblitz.com/github/antfu/vitesse?startScript=dev)
 
 Click on it and see the effect yourself!
 :::
@@ -68,9 +68,9 @@ For instance, the URL from the previous section would now become:
 [stackblitz.com/github/antfu/vitesse?title=Hello](https://stackblitz.com/github/antfu/vitesse?title=Hello)
 
 :::tip
-You can chain the URL query parameters by adding the & sing between them, for example:
+You can chain the URL query parameters by adding the `&` sign between them, for example:
 
-[stackblitz.com/github/antfu/vitesse?title=Hello](https://stackblitz.com/github/antfu/vitesse?title=Hello&terminal=dev)
+[stackblitz.com/github/antfu/vitesse?title=Hello](https://stackblitz.com/github/antfu/vitesse?title=Hello&startScript=dev)
 :::
 
 ## Importing private projects

--- a/docs/platform/webcontainers/browser-config-brave.md
+++ b/docs/platform/webcontainers/browser-config-brave.md
@@ -14,11 +14,11 @@ WebContainers work in Brave almost out of the box. However, it might require a s
 
 By default, Brave’s “Shields” feature blocks [Service Workers](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API) and cookies from third-party domains.
 
-When you visit a WebContainers-enabled project on [stackblitz.com](https://www.stackblitz.com/), StackBlitz tries to register a Service Worker for the domain `<project_name>.stackblitz.io`. Since it’s considered a third-party domain, Brave will reject it.
+When you visit a WebContainers-enabled project on [stackblitz.com](https://stackblitz.com/), StackBlitz tries to register a Service Worker for the domain `<project_name>.stackblitz.io`. Since it’s considered a third-party domain, Brave will reject it.
 
 ## Allowing third-party Service Workers
 
-1. Visit a WebContainers-based project, for instance https://www.stackblitz.com/edit/nextjs. The project’s boot sequence might stay stuck on the “Running start command” step:
+1. Visit a WebContainers-based project, for instance https://stackblitz.com/edit/nextjs. The project’s boot sequence might stay stuck on the “Running start command” step:
 
 ![Screenshot of Brave on a WebContainers project with the Brave Shields feature on. Loading the project’s web server is stuck on the last step.](./assets/brave-stuck-project.png)
 

--- a/docs/platform/webcontainers/project-config.md
+++ b/docs/platform/webcontainers/project-config.md
@@ -125,24 +125,24 @@ A map of default environment variables that will be set in each top-level shell 
 
 ## With URL parameters
 
-### <var>terminal</var>
+### <var>startScript</var>
 
-Use the `terminal` parameter in the project’s URL query string to select one or several scripts from `package.json` to run on project load.
+Use the `startScript` parameter in the project’s URL query string to select one or several scripts from `package.json` to run on project load.
 
 This can be useful when a project doesn’t define a custom `startCommand`, or if you want to share a link that runs a different script than the one specified in `startCommand`.
 
 For example, the following URL will run the `"test"` script, defined in `package.json`, on project load:
 
 ```
-https://stackblitz.com/edit/project-id?terminal=test
+https://stackblitz.com/edit/project-id?startScript=test
 ```
 
 :::warning
-The `terminal` parameter only accepts existing keys from the `scripts` field in `package.json`. Projects which need more control should use [configuration in the project files](#with-project-files) directly.
+The `startScript` parameter only accepts existing keys from the `scripts` field in `package.json`. Projects which need more control should use [configuration in the project files](#with-project-files) directly.
 :::
 
 You can also run several scripts sequentially using comma-separated values. For instance, if a project defines a `"build"` script and a `"serve"` script, and both are needed to render a web page, you could use:
 
 ```
-https://stackblitz.com/edit/project-id?terminal=build,serve
+https://stackblitz.com/edit/project-id?startScript=build,serve
 ```


### PR DESCRIPTION
# PR Description

This PR fixes the issue number: n.a.

### Summary of my changes and explanation of my decisions

We recently renamed the `terminal` query parameter to `startScript`. The old name is still technically supported, but we want to use the new (and hopefully clearer) name in our docs.

This is mostly a straightforward replacement, but I did rewrite a couple paragraphs in the GitHub integration guide (“Launching a script on project load” section). It’s just a suggestion, so I’m okay with pushback on those changes or rewrites of my rewrite. :)

### Self-check

Please check all that apply:

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my code or content update and edited it to the best of my abilities
- [ ] I have commented my code, particularly in hard-to-understand areas; my comments are concise

### Contributors list

Would you like your contribution to be celebrated? Please check all that apply:

- [ ] I would like to be featured on the future contributors list in the README. If so, please tell us:
  - what name you'd like to be shown there?
  - we usually link github profile pic -- is that ok? If not, provide another url: 
  - we usually link your github profile but if you have a portfolio page, provide a link:

- [ ] I would like to get a shoutout in the next monthly updates post. If so, please provide your twitter handle (or we will link to your GitHub profile).

⚡️ ⚡️ ⚡️  Thank you for contributing to StackBlitz ⚡️ ⚡️ ⚡️ 
