### PR TITLE
Making the Web Publisher docs page more engaging for new users

### DIFF
--- a/docs/codeflow/content-updates-with-web-publisher.md
+++ b/docs/codeflow/content-updates-with-web-publisher.md
@@ -27,7 +27,9 @@ To edit a page, you need to find its corresponding file on GitHub. You can do it
 
 ### "Edit in Web Publisher" button
 
-<img lang="en" class="float-left" src="/img/edit_in_web_publisher.svg" alt="Edit in Web Publisher button" style="width: 150px; margin-top: 4%;"/>
+<a href="https://pr.new/stackblitz/docs/edit/main/docs/codeflow/content-updates-with-web-publisher.md"> 
+<img lang="en" class="float-left" src="/img/edit_in_web_publisher.svg" alt="Edit in Web Publisher button" style="width: 150px; margin-top: 4%;"/> 
+</a>
 
 If the page features our button, that's it! Click on it and you will be redirected to our friendly publishing tool 💕
 


### PR DESCRIPTION
# PR Description
Updating the web publisher page so that the "Edit in Web Publisher" button takes you into web publisher to edit that page. I did this since we link to this page from the Webcontainer API blog post and I tried to click this button to see what the Web Publisher experience was like and it wasn't hyperlinked and I was disappointed as a naive user

### Summary of my changes and explanation of my decisions

- Adding a link to https://pr.new/stackblitz/docs/edit/main/docs/codeflow/content-updates-with-web-publisher.md to the "Edit in Web Publisher" button that sits on that page

### Self-check

Please check all that apply:

- [? ] My code follows the style guidelines of this project
- [ X] I have reviewed my code or content update and edited it to the best of my abilities
- [ X] I have commented my code, particularly in hard-to-understand areas; my comments are concise

### Contributors list

Would you like your contribution to be celebrated? Please check all that apply:

- [ ] I would like to be featured on the future contributors list in the README. If so, please tell us:
  - what name you'd like to be shown there?
  - we usually link github profile pic -- is that ok? If not, provide another url: 
  - we usually link your github profile but if you have a portfolio page, provide a link:

- [ ] I would like to get a shoutout in the next monthly updates post. If so, please provide your twitter handle (or we will link to your GitHub profile).

⚡️ ⚡️ ⚡️  Thank you for contributing to StackBlitz ⚡️ ⚡️ ⚡️ 


-----

<a href="https://stackblitz.com/~/github.com/stackblitz/docs/tree/web-publisher/kc0tlh/content-updates-with-web-publisher"><img src="https://developer.stackblitz.com/img/review_pr_small.svg" alt="Review PR in StackBlitz Codeflow" align="left" width="103" height="20"></a> _Submitted with [StackBlitz Web Publisher](https://developer.stackblitz.com/codeflow/integrating-web-publisher)._