### PR TITLE
fix: serve images with corp header

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,4 @@
+[[headers]]
+  for = "/img/*"
+  [headers.values]
+    Cross-Origin-Resource-Policy = "cross-origin"


### PR DESCRIPTION
# PR Description

This PR updates the netlify deployment so that images are served with a `CORP: cross-origin` header. This allows the images to be used on cross-origin isolated websites.

### Summary of my changes and explanation of my decisions

The problem is that the images are not served with a `CORP` header. This means that they cannot be used on websites that are cross-origin isolated.

### Self-check

Please check all that apply:

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my code or content update and edited it to the best of my abilities
- [x] I have commented my code, particularly in hard-to-understand areas; my comments are concise

### Contributors list

Would you like your contribution to be celebrated? Please check all that apply:

- [ ] I would like to be featured on the future contributors list in the README. If so, please tell us:
  - what name you'd like to be shown there?
  - we usually link github profile pic -- is that ok? If not, provide another url: 
  - we usually link your github profile but if you have a portfolio page, provide a link:

- [ ] I would like to get a shoutout in the next monthly updates post. If so, please provide your twitter handle (or we will link to your GitHub profile).

⚡️ ⚡️ ⚡️  Thank you for contributing to StackBlitz ⚡️ ⚡️ ⚡️ 
