### PR TITLE
Update browser support page

### DIFF
--- a/docs/platform/webcontainers/browser-support.md
+++ b/docs/platform/webcontainers/browser-support.md
@@ -1,6 +1,6 @@
 ---
 title: &title WebContainers Browser Support
-description: &description For WebContainers, we support desktop Chromium-based browsers out of the box, and Firefox in alpha state.
+description: &description For WebContainers, we support desktop Chromium-based browsers out of the box, Safari 16.4 TP, and Firefox in alpha state.
 head:
   - ['meta', {property: 'og:title', content: *title}] 
   - ['meta', {property: 'og:image', content: 'https://developer.stackblitz.com/img/og/webcontainer-browser-support.png'}]
@@ -12,7 +12,7 @@ head:
 
 _Last update: February 2023_
 
-**TL;DR** For WebContainers, we support desktop Chromium-based browsers out of the box, and Firefox in alpha state. If you have issues with supported browsers, [check your browser configuration](/platform/webcontainers/browser-config).
+**TL;DR** For WebContainers, we support desktop Chromium-based browsers out of the box, Safari 16.4 TP, and Firefox in alpha state. If you have issues with supported browsers, [check your browser configuration](/platform/webcontainers/browser-config).
 
 :::warning Note
 There is a reported Chrome regression on Macbooks with M1 chip, which also affects the speed of some larger projects on WebContainers. Learn more about this issue in these bug reports: [issue 1228686](https://bugs.chromium.org/p/chromium/issues/detail?id=1228686) and [issue 1356099](https://bugs.chromium.org/p/chromium/issues/detail?id=1356099).
@@ -22,7 +22,7 @@ There is a reported Chrome regression on Macbooks with M1 chip, which also affec
 
 StackBlitz requires some of the latest additions to the Web Platform to work correctly when running WebContainers-based projects. Most important among them are **[`SharedArrayBuffer`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer)** and **[cross-origin isolation](https://developer.mozilla.org/en-US/docs/Web/API/crossOriginIsolated)**.
 
-`SharedArrayBuffer`s (SABs) allow simultaneous access to a chunk of memory from multiple different workers. This is a powerful feature that was [disabled temporarily](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer#security_requirements) in light of potential security issues. Cross-origin isolation is the key to enabling SABs: by properly configuring some of the headers and controlling which resources are served to browsers, a site can be considered `crossOriginIsolated` or, in other words, secure enough to use SABs. Both features are enabled in Chromium-based browsers (Chrome, Brave, Edge) and Firefox.
+`SharedArrayBuffer`s (SABs) allow simultaneous access to a chunk of memory from multiple different workers. This is a powerful feature that was [disabled temporarily](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer#security_requirements) in light of potential security issues. Cross-origin isolation is the key to enabling SABs: by properly configuring some of the headers and controlling which resources are served to browsers, a site can be considered `crossOriginIsolated` or, in other words, secure enough to use SABs. Both features are enabled in Chromium-based browsers (Chrome, Brave, Edge), Safari 16.4 TP, and Firefox.
 
 However, for cross-origin isolation to work for our use case, you need to be able to embed arbitrary resources: to be able to write and test your web application seamlessly, regardless of which images or scripts you choose to include. For this to work, a [new mode](https://github.com/WICG/credentiallessness) of cross-origin isolation that allows this is needed.
 
@@ -62,12 +62,14 @@ In addition to this, there might be [other runtime incompatibilities](#runtime-d
 
 ## Safari
 
-Safari recently shipped support for `SharedArrayBuffer` and cross-origin isolation in a somewhat [buggy state](https://bugs.webkit.org/show_bug.cgi?id=238442). In addition to this, it is still lacking a few other features which prevents us from shipping a working environment such as:
+Starting with Safari 16.4 TP, WebContainers fully work in Safari.
+
+Older versions of the browser are still lacking a few other features necessary for WebContainers to run, such as:
 
 * [Atomics.waitAsync](https://github.com/tc39/proposal-atomics-wait-async)
 * [Lookbehind in regular expressions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Assertions)
 
-Note that none of above can be pollyfilled.
+These cannot be pollyfilled.
 
 ## Embedding
 

--- a/docs/platform/webcontainers/browser-support.md
+++ b/docs/platform/webcontainers/browser-support.md
@@ -62,7 +62,7 @@ In addition to this, there might be [other runtime incompatibilities](#runtime-d
 
 ## Safari
 
-Starting with Safari 16.4 TP, WebContainers fully work in Safari.
+Starting with Safari 16.4 TP,  WebContainers are in beta for Safari.
 
 Older versions of the browser are still lacking a few other features necessary for WebContainers to run, such as:
 

--- a/docs/platform/webcontainers/browser-support.md
+++ b/docs/platform/webcontainers/browser-support.md
@@ -62,7 +62,7 @@ In addition to this, there might be [other runtime incompatibilities](#runtime-d
 
 ## Safari
 
-Starting with Safari 16.4 TP,  WebContainers are in beta for Safari.
+Starting with Safari 16.4 TP, WebContainers are in beta for Safari.
 
 Older versions of the browser are still lacking a few other features necessary for WebContainers to run, such as:
 

--- a/docs/platform/webcontainers/browser-support.md
+++ b/docs/platform/webcontainers/browser-support.md
@@ -12,7 +12,7 @@ head:
 
 _Last update: February 2023_
 
-**TL;DR** For WebContainers, we support desktop Chromium-based browsers out of the box, Safari 16.4 TP, and Firefox in alpha state. If you have issues with supported browsers, [check your browser configuration](/platform/webcontainers/browser-config).
+**TL;DR** For WebContainers, we support desktop Chromium-based browsers out of the box, as well as Safari 16.4 TP and Firefox, which both are in alpha state. If you have issues with supported browsers, [check your browser configuration](/platform/webcontainers/browser-config).
 
 :::warning Note
 There is a reported Chrome regression on Macbooks with M1 chip, which also affects the speed of some larger projects on WebContainers. Learn more about this issue in these bug reports: [issue 1228686](https://bugs.chromium.org/p/chromium/issues/detail?id=1228686) and [issue 1356099](https://bugs.chromium.org/p/chromium/issues/detail?id=1356099).

--- a/docs/platform/webcontainers/browser-support.md
+++ b/docs/platform/webcontainers/browser-support.md
@@ -1,6 +1,6 @@
 ---
 title: &title WebContainers Browser Support
-description: &description For WebContainers, we support desktop Chromium-based browsers out of the box, as well as Safari 16.4 TP and Firefox, which both are in alpha state.
+description: &description For WebContainers, we support desktop Chromium-based browsers out of the box, as well as Safari 16.4 TP and Firefox, which both are in beta.
 head:
   - ['meta', {property: 'og:title', content: *title}] 
   - ['meta', {property: 'og:image', content: 'https://developer.stackblitz.com/img/og/webcontainer-browser-support.png'}]

--- a/docs/platform/webcontainers/browser-support.md
+++ b/docs/platform/webcontainers/browser-support.md
@@ -1,6 +1,6 @@
 ---
 title: &title WebContainers Browser Support
-description: &description For WebContainers, we support desktop Chromium-based browsers out of the box, Safari 16.4 TP, and Firefox in alpha state.
+description: &description For WebContainers, we support desktop Chromium-based browsers out of the box, as well as Safari 16.4 TP and Firefox, which both are in alpha state.
 head:
   - ['meta', {property: 'og:title', content: *title}] 
   - ['meta', {property: 'og:image', content: 'https://developer.stackblitz.com/img/og/webcontainer-browser-support.png'}]

--- a/docs/platform/webcontainers/browser-support.md
+++ b/docs/platform/webcontainers/browser-support.md
@@ -12,7 +12,7 @@ head:
 
 _Last update: February 2023_
 
-**TL;DR** For WebContainers, we support desktop Chromium-based browsers out of the box, as well as Safari 16.4 TP and Firefox, which both are in alpha state. If you have issues with supported browsers, [check your browser configuration](/platform/webcontainers/browser-config).
+**TL;DR** For WebContainers, we support desktop Chromium-based browsers out of the box, as well as Safari 16.4 TP and Firefox, which both are in beta. If you have issues with supported browsers, [check your browser configuration](/platform/webcontainers/browser-config).
 
 :::warning Note
 There is a reported Chrome regression on Macbooks with M1 chip, which also affects the speed of some larger projects on WebContainers. Learn more about this issue in these bug reports: [issue 1228686](https://bugs.chromium.org/p/chromium/issues/detail?id=1228686) and [issue 1356099](https://bugs.chromium.org/p/chromium/issues/detail?id=1356099).


### PR DESCRIPTION
# PR Description

Important update about Safari 16.4 TP.

### Summary of my changes and explanation of my decisions

- Changed the page description
- Changed the Safari section
- Added mention of safari in "Web Platform requirements"

-----
<a href="https://stackblitz.com/~/github.com/stackblitz/docs/tree/web-publisher/sylwiavargas/browser-support"><img src="https://developer.stackblitz.com/img/review_pr_small.svg" alt="Review PR in StackBlitz Codeflow" align="left" width="103" height="20"></a> _Submitted with [StackBlitz Web Publisher](https://developer.stackblitz.com/codeflow/integrating-web-publisher)._