### PR TITLE
Remove warning about Chrome M1 perf limitations (fixed in Chrome 112)

### DIFF
--- a/docs/platform/webcontainers/browser-support.md
+++ b/docs/platform/webcontainers/browser-support.md
@@ -14,10 +14,6 @@ _Last update: February 2023_
 
 **TL;DR** For WebContainers, we support desktop Chromium-based browsers out of the box, as well as Safari 16.4 TP and Firefox, which both are in beta. If you have issues with supported browsers, [check your browser configuration](/platform/webcontainers/browser-config).
 
-:::warning Note
-There is a reported Chrome regression on Macbooks with M1 chip, which also affects the speed of some larger projects on WebContainers. Learn more about this issue in these bug reports: [issue 1228686](https://bugs.chromium.org/p/chromium/issues/detail?id=1228686) and [issue 1356099](https://bugs.chromium.org/p/chromium/issues/detail?id=1356099).
-:::
-
 ## Web Platform requirements
 
 StackBlitz requires some of the latest additions to the Web Platform to work correctly when running WebContainers-based projects. Most important among them are **[`SharedArrayBuffer`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer)** and **[cross-origin isolation](https://developer.mozilla.org/en-US/docs/Web/API/crossOriginIsolated)**.
@@ -41,10 +37,6 @@ WebContainers are fully supported in Chrome and most Chromium-based browsers inc
 However, if you enabled blocking third-party cookies in Chrome preferences, this may prevent WebContainers from working out of the box.
 
 If you think you’re running into this issue, check out [how to configure Chrome to run WebContainers](/platform/webcontainers/browser-config#chrome-service-workers).
-
-:::warning Note
-There is a reported Chrome regression on Macbooks with M1 chip, which also affects the speed of some larger projects on WebContainers. Learn more about this issue in these bug reports: [issue 1228686](https://bugs.chromium.org/p/chromium/issues/detail?id=1228686) and [issue 1356099](https://bugs.chromium.org/p/chromium/issues/detail?id=1356099).
-:::
 
 ## Brave
 


### PR DESCRIPTION
# PR Description

This PR fixes the issue number: n.a.

### Summary of my changes and explanation of my decisions

Remove the warning about Chrome on Apple ARM (M1, M2) performance limitations.

Fixes for those issues landed in Chrome 112, currently in beta.

Chrome 112 ships April 4th, so we can wait until then to merge this PR.

