### PR TITLE
Separate the Enterprise Edition sidebar from the main content

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -2,7 +2,7 @@ import dotenv from 'dotenv';
 /* @ts-expect-error */
 import mdFootnote from 'markdown-it-footnote';
 import { defineConfig, type HeadConfig } from 'vitepress';
-import { defaultGroupLink, linkGroup } from '../docs/links';
+import { defaultGroupLink, sidebarLinks } from '../docs/links';
 
 dotenv.config();
 
@@ -40,12 +40,12 @@ export default defineConfig({
       { text: 'Enterprise', link: defaultGroupLink('enterprise') },
     ],
     sidebar: {
-      '/guides/': linkGroup(['userGuide', 'integrationGuide']),
-      '/codeflow/': linkGroup('codeflow'),
-      '/platform/api/': linkGroup('api'),
-      '/platform/webcontainers/': linkGroup('webcontainers'),
-      '/enterprise/': linkGroup('enterprise'),
-    }
+      '/guides/': sidebarLinks('main', ['userGuide', 'integrationGuide']),
+      '/codeflow/': sidebarLinks('main', ['codeflow']),
+      '/platform/api/': sidebarLinks('main', ['api']),
+      '/platform/webcontainers/': sidebarLinks('main', ['webcontainers']),
+      '/enterprise/': sidebarLinks('enterprise', ['enterprise']),
+    },
   },
 
   markdown: {

--- a/docs/links.ts
+++ b/docs/links.ts
@@ -2,20 +2,20 @@
 // Link Groups / Sidebar
 
 type LinkGroup =
-  'api'|
-  'codeflow'|
-  'enterprise'|
-  'integrationGuide'|
-  'userGuide'|
-  'webcontainers';
+  | 'api'
+  | 'codeflow'
+  | 'enterprise'
+  | 'integrationGuide'
+  | 'userGuide'
+  | 'webcontainers';
 
 interface LinkItem {
   text: string;
   link: string;
-  items?: LinkItem[]
+  items?: LinkItem[];
 }
 
-const groupLinks: {[key in LinkGroup]: LinkItem[]} = {
+const groupLinks: Record<LinkGroup, LinkItem[]> = {
   userGuide: [
     { text: 'What is StackBlitz', link: '/guides/user-guide/what-is-stackblitz' },
     { text: 'Getting started', link: '/guides/user-guide/getting-started' },
@@ -93,7 +93,7 @@ const groupLinks: {[key in LinkGroup]: LinkItem[]} = {
   ],
 };
 
-const linkGroups: {[key in LinkGroup]: {text: string, items: LinkItem[]}} = {
+const linkGroups: Record<LinkGroup, { text: string; items: LinkItem[] }> = {
   userGuide: {
     text: 'User Guide',
     items: groupLinks.userGuide,
@@ -122,15 +122,21 @@ const linkGroups: {[key in LinkGroup]: {text: string, items: LinkItem[]}} = {
 
 export const defaultGroupLink = (linkGroup: LinkGroup) => groupLinks[linkGroup][0].link;
 
-export const linkGroup = (activeLinkGroup: LinkGroup | LinkGroup[]) => (
-  Object.keys(linkGroups).map((linkGroup: string) => ({
-    ...linkGroups[linkGroup as LinkGroup],
-    collapsible: true,
-    collapsed: typeof activeLinkGroup === 'string' 
-      ? activeLinkGroup !== linkGroup
-      : !activeLinkGroup.includes(linkGroup as LinkGroup)
-  }))
-);
+export const sidebarLinks = (
+  sidebar: 'main' | 'enterprise',
+  activeLinkGroups: LinkGroup[] = []
+) => {
+  if (sidebar === 'enterprise') {
+    return [linkGroups.enterprise];
+  }
+
+  return Object.entries(linkGroups)
+    .filter(([key]) => key !== 'enterprise')
+    .map(([key, data]) => ({
+      ...data,
+      collapsed: !activeLinkGroups.includes(key as LinkGroup),
+    }));
+};
 
 // --------------------------------
 // Home
@@ -204,7 +210,7 @@ export const homeExternalLinks = [
 // --------------------------------
 // Footer
 
-export const footerSections = [
+export const footerSections: Array<{ title: string; items: LinkItem[] }> = [
   {
     title: 'Workspaces',
     items: [


### PR DESCRIPTION
# PR Description

This PR is a follow-up to #104.

### Summary of my changes and explanation of my decisions

When we redesigned our docs in September 2022 we wanted to have specific sidebars for each section of top-level content, and in particular we wanted to put the Enterprise Edition content in its own sidebar.

In #104 we changed that to have a single sidebar with all the docs content, including the Enteprise Edition-specific content, in collapsible sections, to be consistent with the https://webcontainers.io docs.

This PR undoes part of this change, by putting the Enterprise Edition sidebar content back in its own group.

Main sidebar (no EE section):

<img alt="sidebar-1-main" width="272" src="https://user-images.githubusercontent.com/243601/229594201-139ddbab-cf71-4831-b087-fe4495455e5c.png">

EE-specific sidebar:

<img alt="sidebar-2-ee" width="272" src="https://user-images.githubusercontent.com/243601/229594271-935d1a42-cb4f-4f47-b78b-3fd1aa5e8920.png">

### Self-check

Please check all that apply:

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my code or content update and edited it to the best of my abilities
- [ ] I have commented my code, particularly in hard-to-understand areas; my comments are concise

### Contributors list

Would you like your contribution to be celebrated? Please check all that apply:

- [ ] I would like to be featured on the future contributors list in the README. If so, please tell us:
  - what name you'd like to be shown there?
  - we usually link github profile pic -- is that ok? If not, provide another url: 
  - we usually link your github profile but if you have a portfolio page, provide a link:

- [ ] I would like to get a shoutout in the next monthly updates post. If so, please provide your twitter handle (or we will link to your GitHub profile).

⚡️ ⚡️ ⚡️  Thank you for contributing to StackBlitz ⚡️ ⚡️ ⚡️ 
