### PR TITLE
fix: Correctly wrap headings

### DIFF
--- a/.vitepress/theme/styles/fixes.scss
+++ b/.vitepress/theme/styles/fixes.scss
@@ -140,6 +140,7 @@
 .vp-doc h5,
 .vp-doc h6 {
   width: max-content;
+  max-width: 100%;
 }
 .vp-doc h1 + p,
 .vp-doc h2 + p {


### PR DESCRIPTION
Headings weren't wrapping correctly, now they are.

|Old|New|
|-|-|
|<img width="483" alt="Screen Shot 2023-04-03 at 1 52 34 PM" src="https://user-images.githubusercontent.com/22125230/229613025-10e556d7-4197-4a91-9ca3-d480abe05c99.png">|<img width="483" alt="Screen Shot 2023-04-03 at 1 52 25 PM" src="https://user-images.githubusercontent.com/22125230/229613039-e5826eb0-fec8-4991-85e1-95b1aa0229f7.png">|

### Self-check

Please check all that apply:

- [x ] My code follows the style guidelines of this project
- [x ] I have reviewed my code or content update and edited it to the best of my abilities
- [ ] I have commented my code, particularly in hard-to-understand areas; my comments are concise


⚡️ ⚡️ ⚡️  Thank you for contributing to StackBlitz ⚡️ ⚡️ ⚡️ 
