### PR TITLE
feat: add docs for `configPath`

### DIFF
--- a/docs/guides/integration/open-from-github.md
+++ b/docs/guides/integration/open-from-github.md
@@ -146,8 +146,7 @@ If you want to run a different script or command, you can use one of the followi
   }
   ```
 
-If your project has multiple folders with their own `package.json` files, you can change where StackBlitz will look up by using
-`configPath` query parameter:
+If your project has multiple folders with their own `package.json` files, you can specify which folder should open by using the `configPath` query parameter:
 ```
 ?configPath=packages/docs
 ```

--- a/docs/guides/integration/open-from-github.md
+++ b/docs/guides/integration/open-from-github.md
@@ -146,6 +146,12 @@ If you want to run a different script or command, you can use one of the followi
   }
   ```
 
+If your project has multiple folders with their own `package.json` files, you can change where StackBlitz will look up by using
+`configPath` query parameter:
+```
+?configPath=packages/docs
+```
+
 ## Tips & best practices
 
 ### Keep the `package-lock.json` file


### PR DESCRIPTION
# PR Description

We now support changing where StackBlitz will look up for config file by appending `configPath` in the URL. 
So I'm adding its docs 🙇 

### Self-check

Please check all that apply:

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my code or content update and edited it to the best of my abilities
- [x] I have commented my code, particularly in hard-to-understand areas; my comments are concise

### Contributors list

Would you like your contribution to be celebrated? Please check all that apply:

- [ ] I would like to be featured on the future contributors list in the README. If so, please tell us:
  - what name you'd like to be shown there?
  - we usually link github profile pic -- is that ok? If not, provide another url: 
  - we usually link your github profile but if you have a portfolio page, provide a link:

- [ ] I would like to get a shoutout in the next monthly updates post. If so, please provide your twitter handle (or we will link to your GitHub profile).

⚡️ ⚡️ ⚡️  Thank you for contributing to StackBlitz ⚡️ ⚡️ ⚡️ 
