### PR TITLE
Remove @types/gtag.js dep which fails in Codeflow

### DIFF
--- a/.vitepress/theme/scripts/gtag.ts
+++ b/.vitepress/theme/scripts/gtag.ts
@@ -6,8 +6,9 @@ interface GtagEvent {
 }
 
 export function sendEvent({ eventName, pagePath, value }: GtagEvent) {
-  if (typeof window.gtag === 'function') {
-    window.gtag('event', eventName, {
+  const gtag: any = (window as any).gtag;
+  if (typeof gtag === 'function') {
+    gtag('event', eventName, {
       page_path: pagePath,
       value,
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "vue": "^3.2.45"
       },
       "devDependencies": {
-        "@types/gtag.js": "^0.0.12",
         "@types/node": "^16.18.3",
         "@vue/tsconfig": "^0.1.3",
         "dotenv": "^16.0.3",
@@ -548,12 +547,6 @@
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/@stackblitz/sdk/-/sdk-1.8.2.tgz",
       "integrity": "sha512-3aTg0Tb9dNs1huPkpdYxPEX/yc8A28eZneUMOEJzOLi7EJwl5onr9gCAVjIOkN4WLYu1iBSiJiGBYT629bZIJQ=="
-    },
-    "node_modules/@types/gtag.js": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/@types/gtag.js/-/gtag.js-0.0.12.tgz",
-      "integrity": "sha512-YQV9bUsemkzG81Ea295/nF/5GijnD2Af7QhEofh7xu+kvCN6RdodgNwwGWXB5GMI3NoyvQo0odNctoH/qLMIpg==",
-      "dev": true
     },
     "node_modules/@types/node": {
       "version": "16.18.20",
@@ -1658,12 +1651,6 @@
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/@stackblitz/sdk/-/sdk-1.8.2.tgz",
       "integrity": "sha512-3aTg0Tb9dNs1huPkpdYxPEX/yc8A28eZneUMOEJzOLi7EJwl5onr9gCAVjIOkN4WLYu1iBSiJiGBYT629bZIJQ=="
-    },
-    "@types/gtag.js": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/@types/gtag.js/-/gtag.js-0.0.12.tgz",
-      "integrity": "sha512-YQV9bUsemkzG81Ea295/nF/5GijnD2Af7QhEofh7xu+kvCN6RdodgNwwGWXB5GMI3NoyvQo0odNctoH/qLMIpg==",
-      "dev": true
     },
     "@types/node": {
       "version": "16.18.20",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "vue": "^3.2.45"
   },
   "devDependencies": {
-    "@types/gtag.js": "^0.0.12",
     "@types/node": "^16.18.3",
     "@vue/tsconfig": "^0.1.3",
     "dotenv": "^16.0.3",


### PR DESCRIPTION
# PR Description

This PR fixes the issue number: #129

### Summary of my changes and explanation of my decisions

- Removes the `@types/gtag.js` npm package, which was used only minimally to get autocompletion for the `window.gtag` function.
- Add a custom type for `window.gtag` in the only function that uses it.
- Now this project installs in Codeflow IDE even if you have an ad blocker that tries to block URLs containing `/gtag.js`.

### Self-check

Please check all that apply:

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my code or content update and edited it to the best of my abilities
- [ ] I have commented my code, particularly in hard-to-understand areas; my comments are concise

### Contributors list

Would you like your contribution to be celebrated? Please check all that apply:

- [ ] I would like to be featured on the future contributors list in the README. If so, please tell us:
  - what name you'd like to be shown there?
  - we usually link github profile pic -- is that ok? If not, provide another url: 
  - we usually link your github profile but if you have a portfolio page, provide a link:

- [ ] I would like to get a shoutout in the next monthly updates post. If so, please provide your twitter handle (or we will link to your GitHub profile).

⚡️ ⚡️ ⚡️  Thank you for contributing to StackBlitz ⚡️ ⚡️ ⚡️ 

-----
<a href="https://stackblitz.com/~/github.com/stackblitz/docs/tree/fvsch%2Fremove-types-gtag-js"><img src="https://developer.stackblitz.com/img/review_pr_small.svg" alt="Review PR in StackBlitz Codeflow" align="left" width="103" height="20"></a> _Submitted with [StackBlitz Codeflow](https://stackblitz.com/~/github.com/stackblitz/docs/tree/fvsch%2Fremove-types-gtag-js)._