### PR TITLE
troubleshooting: add guidance on how to fix 'conflicting peer dependency error

### DIFF
--- a/docs/platform/webcontainers/troubleshooting-webcontainers.md
+++ b/docs/platform/webcontainers/troubleshooting-webcontainers.md
@@ -17,3 +17,12 @@ This page helps you troubleshoot issues with WebContainers.
 Currently, WebContainers can only execute languages that are natively supported on the Web, including JavaScript and WebAssembly. It is not possible to run [native addons](https://nodejs.org/api/addons.html) which are usually implemented using native languages such as C++, unless they can be compiled to WebAssembly. Therefore, loading native addons is disabled by default via [`--no-addons`](https://nodejs.org/api/cli.html#--no-addons) in WebContainers. As a result, you may encounter an error that says: `Cannot load native addon because loading addons is disabled`.
 
 The solution to this is to use an alternative to the native addon which is either fully implemented in JavaScript or can be compiled to WebAssembly.
+
+## Fixing `npm ERR! code ERESOLVE`
+
+With the release of native npm, using `npm` in a terminal no longer use [`turbo`](turbo-package-manager.md) but instead uses the real [npm](https://github.com/npm/cli). There are a few differences in how `npm` and `turbo` resolve dependencies and one of them is how they work with peer dependencies. `npm install` might now fail on your project with an error saying `code ERESOLVE` or `Conflicting peer dependency`. You can easily fix this error by either:
+
+ 1. Removing your `package-lock.json` file, re-running `npm install` and save your project
+ 2. Running `npm install --legacy-peer-deps`
+
+Your project should still load fine as when StackBlitz detect this error it will re-run the installation step with `npm install --legacy-peer-deps`.


### PR DESCRIPTION
# PR Description

This PR add help on how to fix `Conflicting peer dependency` errors on StackBlitz that users will likely face once we rollout native npm.

### Summary of my changes and explanation of my decisions

Provide solutions to remove the error below from the terminal on projects relying on `turbo`'s behaviour for resolving dependencies:

```
npm ERR! code ERESOLVE
npm ERR! ERESOLVE could not resolve
npm ERR! 
npm ERR! While resolving:
npm ERR! 
npm ERR! ...
npm ERR! 
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
```

### Self-check

Please check all that apply:

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my code or content update and edited it to the best of my abilities
- [x] I have commented my code, particularly in hard-to-understand areas; my comments are concise