### PR TITLE
fix: case studies page

### DIFF
--- a/docs/links.ts
+++ b/docs/links.ts
@@ -246,7 +246,7 @@ export const footerSections: Array<{ title: string; items: LinkItem[] }> = [
       { text: 'Docs', link: 'https://developer.stackblitz.com/' },
       { text: 'Enterprise', link: 'https://stackblitz.com/enterprise' },
       { text: 'Pricing', link: 'https://stackblitz.com/membership' },
-      { text: 'Case Studies', link: 'https://stackblitz.com/case-studies/google' },
+      { text: 'Case Studies', link: 'https://stackblitz.com/case-studies' },
     ],
   },
   {


### PR DESCRIPTION
This fixes the case studies link to link to the new page

-----
<a href="https://stackblitz.com/~/github/stackblitz/docs/tree/samdenty%2Ffix-case-studies"><img src="https://developer.stackblitz.com/img/review_pr_small.svg" alt="Review PR in StackBlitz Codeflow" align="left" width="103" height="20"></a> _Submitted with [StackBlitz Codeflow](https://stackblitz.com/~/github/stackblitz/docs/tree/samdenty%2Ffix-case-studies)._