### PR TITLE
fix broken discord link

### DIFF
--- a/docs/links.ts
+++ b/docs/links.ts
@@ -203,7 +203,7 @@ export const homeExternalLinks = [
     title: 'Community',
     description:
       'Join our supportive community on Discord, ask questions, and share your StackBlitz projects.',
-    url: 'https://discord.com/invite/EQ7uJQxC',
+    url: 'https://discord.gg/stackblitz',
     large: true,
     bgImgLight: '/img/theme/link-bg-squares-light.png',
     bgImgDark: '/img/theme/link-bg-squares-dark.png',


### PR DESCRIPTION
replaces expired discord invite link with permanent link from footer
