### PR TITLE
fix: use the correct form name to send feedback to Netlify 

### DIFF
--- a/.vitepress/theme/components/Feedback/Feedback.vue
+++ b/.vitepress/theme/components/Feedback/Feedback.vue
@@ -85,7 +85,7 @@ watch(
 
 <template>
   <div class="feedbackContainer">
-    <form name="webcontainer-api-doc-feedback" data-netlify="true" hidden>
+    <form name="stackblitz-doc-feedback" data-netlify="true" hidden>
       <textarea name="feedback"></textarea>
       <input name="wasHelpful" />
       <input name="page" />

--- a/.vitepress/theme/components/Feedback/Feedback.vue
+++ b/.vitepress/theme/components/Feedback/Feedback.vue
@@ -14,6 +14,8 @@ enum FeedbackState {
   END = 'END',
 }
 
+const netlifyFormName = 'stackblitz-doc-feedback';
+
 const route = useRoute();
 const currentState = ref(FeedbackState.START);
 const feedback = ref('');
@@ -53,7 +55,7 @@ function submitForm() {
     method: 'POST',
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
     body: encode({
-      'form-name': 'stackblitz-doc-feedback',
+      'form-name': netlifyFormName,
       page: route.path,
       wasHelpful: currentState.value,
       feedback: feedback.value,
@@ -85,7 +87,7 @@ watch(
 
 <template>
   <div class="feedbackContainer">
-    <form name="stackblitz-doc-feedback" data-netlify="true" hidden>
+    <form :name="netlifyFormName" data-netlify="true" hidden>
       <textarea name="feedback"></textarea>
       <input name="wasHelpful" />
       <input name="page" />


### PR DESCRIPTION
# PR Description
We forgot to update the name in form (it should be matched with this [form-name](https://github.com/stackblitz/docs/blob/a3586ca7371d42fd949a1305a04594707342945c/.vitepress/theme/components/Feedback/Feedback.vue#L56)). You can test it on preview, if you send a feedback, the post request should return 200 instead of 404, and you can find the results under Sites > developer.stackblitz.com > Forms on Netlify.