### PR TITLE
chore: rename VITE_GTM_ID env var to VITE_GTAG_ID

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -130,18 +130,18 @@ export default defineConfigWithTheme<ThemeConfig>({
 });
 
 function getAnalyticsTags(env: NodeJS.ProcessEnv): HeadConfig[] {
-  if (!env.VITE_GTM_ID) {
+  if (!env.VITE_GTAG_ID) {
     return [];
   }
   return [
     [
       'script',
-      { src: `https://www.googletagmanager.com/gtag/js?id=${env.VITE_GTM_ID}`, async: '' },
+      { src: `https://www.googletagmanager.com/gtag/js?id=${env.VITE_GTAG_ID}`, async: '' },
     ],
     [
       'script',
       {},
-      `function gtag(){dataLayer.push(arguments)}window.dataLayer=window.dataLayer||[],gtag('js',new Date),gtag('config','${env.VITE_GTM_ID}',{anonymize_ip:true})`,
+      `function gtag(){dataLayer.push(arguments)}window.dataLayer=window.dataLayer||[],gtag('js',new Date),gtag('config','${env.VITE_GTAG_ID}',{anonymize_ip:true})`,
     ],
   ];
 }

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ For production, the docs expect the following environment variables to be define
 
 - `VITE_ALGOLIA_ID`: Algolia `appId`.
 - `VITE_ALGOLIA_KEY`: Algolia `apiKey`.
-- `VITE_GTM_ID`: Google Tag Manager id.
+- `VITE_GTAG_ID`: Google Analytics id.
 
 They can be defined in CI server configuration, or in a `.env` file:
 
@@ -113,7 +113,7 @@ They can be defined in CI server configuration, or in a `.env` file:
 # .env
 VITE_ALGOLIA_ID='******'
 VITE_ALGOLIA_KEY='******'
-VITE_GTM_ID='******'
+VITE_GTAG_ID='******'
 ```
 
 ---


### PR DESCRIPTION
In https://github.com/stackblitz/docs/pull/189 I’m renaming the incorrectly named `VITE_GTM_ID` to `VITE_GTAG_ID`, and using `VITE_GTM_ID` for an actual Google Tag Manager id.

This PR does this renaming only (without any other change), so that we can make both production and preview deploys using the same environment configuration.