### PR TITLE
Fix the height of auth buttons

### DIFF
--- a/.vitepress/theme/components/AuthButtons/AuthButtons.vue
+++ b/.vitepress/theme/components/AuthButtons/AuthButtons.vue
@@ -29,7 +29,7 @@ defineProps<{ place: 'navScreen' | 'navBar' }>();
   }
 
   .link {
-    @media screen and (max-width: 500px) {
+    @media screen and (max-width: 700px) {
       height: 30px;
       padding: 0 10px;
     }

--- a/.vitepress/theme/components/AuthButtons/linkStyles.scss
+++ b/.vitepress/theme/components/AuthButtons/linkStyles.scss
@@ -5,7 +5,7 @@
     --text-strong-color: #fff;
     display: flex;
     align-items: center;
-    height: 32px;
+    height: 36px;
     padding: 0 20px;
     border-radius: 8px;
     color: var(--text-strong-color);


### PR DESCRIPTION
### Summary of changes
The correct size is 36px and it now gets a bit bigger 🌱
<img width="1224" alt="Screenshot 2024-01-30 at 18 21 58" src="https://github.com/stackblitz/docs/assets/3702771/ae5c2aba-a6a6-4131-9e1c-295fc298a9de">

-----
<a href="https://stackblitz.com/~/github/stackblitz/docs/tree/ykmsd%2Fpatch-41300"><img src="https://developer.stackblitz.com/img/review_pr_small.svg" alt="Review PR in StackBlitz" align="left" width="103" height="20"></a> _Submitted with [StackBlitz](https://stackblitz.com/~/github/stackblitz/docs/tree/ykmsd%2Fpatch-41300)._