### PR TITLE
Update DNS wildcard documentation

### DIFF
--- a/docs/enterprise/configuring-dns.md
+++ b/docs/enterprise/configuring-dns.md
@@ -20,7 +20,6 @@ For TLS, your certificate should have `stackblitz.example.com` as the Common Nam
 
 - `stackblitz.example.com`
 - `*.stackblitz.example.com`
-- `*.preview.stackblitz.example.com`
 
 ### TLS Certificate Renewal
 

--- a/docs/enterprise/configuring-dns.md
+++ b/docs/enterprise/configuring-dns.md
@@ -11,7 +11,6 @@ Based off the root DNS zone set in EE Site Configuration (for instance, `stackbl
 ```
 A stackblitz.example.com 172.16.4.20
 A *.stackblitz.example.com 172.16.4.20
-A *.preview.stackblitz.example.com 172.16.4.20
 ```
 
 ## TLS


### PR DESCRIPTION
### Summary of changes

Remove the need to configure a `*.preview` wildcard subdomain.
In newer versions of StackBlitz enterprise this is no longer needed.