### PR TITLE
Fix home page icons

### DIFF
--- a/.vitepress/theme/components/Helpers/CardLink.vue
+++ b/.vitepress/theme/components/Helpers/CardLink.vue
@@ -102,8 +102,7 @@ export default {
     min-width: 100px;
     height: 64px;
     &:not(.has-bg)::before {
-      -webkit-mask-size: 32px;
-              mask-size: 32px;
+      mask-size: 32px;
     }
   }
 
@@ -120,14 +119,10 @@ export default {
     height: 100%;
     transition: background-color 0.14s ease;
     background-color: var(--vp-c-text-3);
-    -webkit-mask-image: var(--icon-img);
-            mask-image: var(--icon-img);
-    -webkit-mask-position: center;
-            mask-position: center;
-    -webkit-mask-repeat: no-repeat;
-            mask-repeat: no-repeat;
-    -webkit-mask-size: var(--icon-mask-size);
-            mask-size: var(--icon-mask-size);
+    mask-image: var(--icon-img);
+    mask-position: center;
+    mask-repeat: no-repeat;
+    mask-size: var(--icon-mask-size);
     .card-body:hover & {
       background-color: var(--vp-c-text-2);
     }
@@ -149,8 +144,7 @@ export default {
     min-width: 84px;
     height: 48px;
     &::before {
-      -webkit-mask-size: 28px;
-              mask-size: 28px;
+      mask-size: 28px;
     }
   }
   &.is-podcast.small,
@@ -159,7 +153,6 @@ export default {
     min-width: 64px;
     height: 48px;
     &::before {
-      -webkit-mask-size: 24px;
       mask-size: 24px;
     }
   }

--- a/.vitepress/theme/components/HomeIntro.vue
+++ b/.vitepress/theme/components/HomeIntro.vue
@@ -31,14 +31,11 @@ header {
   }
 }
 
-$icon-mask: linear-gradient(to bottom, #fff9 10%, #fffa 30%, #fff0 74%);
-
 header .icon {
   width: 160px;
   height: 160px;
   color: var(--sb-foreground-highlight);
-  -webkit-mask-image: $icon-mask;
-  mask-image: $icon-mask;
+  mask-image: linear-gradient(to bottom, #fff9 10%, #fffa 30%, #fff0 74%);
 
   @media (prefers-contrast: more) {
     display: none;

--- a/.vitepress/theme/components/Icons/SvgIcon.vue
+++ b/.vitepress/theme/components/Icons/SvgIcon.vue
@@ -10,10 +10,14 @@ const props = defineProps<{
 
 const styleObj = computed(() => {
   const style: Record<string, string> = {};
-
   const url = iconsUrls[props.icon];
+  
   if (url) {
-    style['--icon'] = `url('${url}')`;
+    // Vite may transform SVG assets to data URLs, using single quotes for XML
+    // attribute values for some reason. This means we can't always quote URLs
+    // with single quotes, or the CSS value might be invalid.
+    const quote = url.includes(`"`) ? `'` : `"`;
+    style['--icon'] = `url(${quote}${url}${quote})`;
   } else {
     style['visibility'] = 'hidden';
     style['--error'] = `'${props.icon} not found'`;
@@ -39,10 +43,12 @@ const styleObj = computed(() => {
   flex: none;
   width: var(--size, 1em);
   height: var(--size, 1em);
-  color: inherit;
-  // Use SVG icon as mask for background
-  -webkit-mask: var(--icon) center/contain no-repeat;
-  mask: var(--icon) center/contain no-repeat;
+  // Use inherited text color to paint a square
   background-color: currentColor;
+  // Then use the SVG icon as mask
+  mask-image: var(--icon);
+  mask-position: center;
+  mask-repeat: no-repeat;
+  mask-size: contain;
 }
 </style>

--- a/.vitepress/theme/styles/custom-block.scss
+++ b/.vitepress/theme/styles/custom-block.scss
@@ -86,13 +86,9 @@
       width: 24px;
       height: 24px;
       background-color: var(--block-icon-color);
-      -webkit-mask-image: var(--block-icon-url);
       mask-image: var(--block-icon-url);
-      -webkit-mask-position: center;
       mask-position: center;
-      -webkit-mask-repeat: no-repeat;
       mask-repeat: no-repeat;
-      -webkit-mask-size: contain;
       mask-size: contain;
       @media (max-width: 500px) {
         left: -40px;

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "markdown-it-footnote": "^3.0.3",
         "prettier": "^3.2.5",
         "sass": "^1.72.0",
-        "vitepress": "~1.0.1"
+        "vitepress": "~1.0.2"
       }
     },
     "node_modules/@algolia/autocomplete-core": {
@@ -1771,9 +1771,9 @@
       }
     },
     "node_modules/vitepress": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.0.1.tgz",
-      "integrity": "sha512-eNr5pOBppYUUjEhv8S0S2t9Tv95LQ6mMeHj6ivaGwfHxpov70Vduuwl/QQMDRznKDSaP0WKV7a82Pb4JVOaqEw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.0.2.tgz",
+      "integrity": "sha512-bEj9yTEdWyewJFOhEREZF+mXuAgOq27etuJZT6DZSp+J3XpQstXMJc5piSVwhZBtuj8OfA0iXy+jdP1c71KMYQ==",
       "dev": true,
       "dependencies": {
         "@docsearch/css": "^3.6.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "markdown-it-footnote": "^3.0.3",
     "prettier": "^3.2.5",
     "sass": "^1.72.0",
-    "vitepress": "~1.0.1"
+    "vitepress": "~1.0.2"
   },
   "prettier": {
     "printWidth": 100,


### PR DESCRIPTION
Our icons on the home page are working correctly in development mode, but not in the final build.

<img width="430" alt="Screenshot 2024-04-02 at 18 46 52" src="https://github.com/stackblitz/docs/assets/243601/fffe6d76-a60d-4555-b63b-70dabe61c9ec">

The icons end up as data URLs in the HTML build, with the SVG attributes quoted with single quotes (instead of double quotes in the source files). And we render those URLs with:

```js
const style = `--icon: url('${url}');`
```

Which breaks when the `url` is something like:

```
data:image/svg+xml,%3csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%20512%20512'%3e…%3c/svg%3e
```

I added some logic to use double quotes when the URL contains single quotes.