### PR TITLE
Update KURL installer notes regarding Host Requirements [OPS-5]

### DIFF
--- a/docs/enterprise/installation/quickstart-gcp.md
+++ b/docs/enterprise/installation/quickstart-gcp.md
@@ -28,7 +28,7 @@ Getting started on GCP (no GKE, no existing cluster):
   - 8080
   - 6443
 - Run the kots intaller command: `curl -sSL https://k8s.kurl.sh/stackblitz | sudo bash`.
-  - **Note:** The KURL installer may prompt some packages for manual installtion. 
+  - **Note:** The KURL installer may prompt some packages for manual installation. 
   See: [Host Package Requirements](https://kurl.sh/docs/add-ons/kubernetes#host-package-requirements).
 
 :::tip Using load balancers?

--- a/docs/enterprise/installation/quickstart-gcp.md
+++ b/docs/enterprise/installation/quickstart-gcp.md
@@ -28,6 +28,7 @@ Getting started on GCP (no GKE, no existing cluster):
   - 8080
   - 6443
 - Run the kots intaller command: `curl -sSL https://k8s.kurl.sh/stackblitz | sudo bash`.
+  - *Note:* The KURL installer may prompt some packages for manual installtion. See: [Host Package Requirements](https://kurl.sh/docs/add-ons/kubernetes#host-package-requirements).
 
 :::tip Using load balancers?
 Ports 80 and 443 should be forwarded from the load balancer. The remaining ports are for inbound rules on the security group.

--- a/docs/enterprise/installation/quickstart-gcp.md
+++ b/docs/enterprise/installation/quickstart-gcp.md
@@ -28,7 +28,8 @@ Getting started on GCP (no GKE, no existing cluster):
   - 8080
   - 6443
 - Run the kots intaller command: `curl -sSL https://k8s.kurl.sh/stackblitz | sudo bash`.
-  - *Note:* The KURL installer may prompt some packages for manual installtion. See: [Host Package Requirements](https://kurl.sh/docs/add-ons/kubernetes#host-package-requirements).
+  - **Note:** The KURL installer may prompt some packages for manual installtion. 
+  See: [Host Package Requirements](https://kurl.sh/docs/add-ons/kubernetes#host-package-requirements).
 
 :::tip Using load balancers?
 Ports 80 and 443 should be forwarded from the load balancer. The remaining ports are for inbound rules on the security group.

--- a/docs/enterprise/installation/quickstart.md
+++ b/docs/enterprise/installation/quickstart.md
@@ -27,7 +27,7 @@ Getting started on bare metal (no existing Kubernetes cluster):
   - 8080
   - 6443
 - Run the kots intaller command: `curl -sSL https://k8s.kurl.sh/stackblitz | sudo bash`.
-  - **Note:** The KURL installer may prompt some packages for manual installtion. 
+  - **Note:** The KURL installer may prompt some packages for manual installation. 
   See: [Host Package Requirements](https://kurl.sh/docs/add-ons/kubernetes#host-package-requirements).
 
 :::tip Using load balancers?

--- a/docs/enterprise/installation/quickstart.md
+++ b/docs/enterprise/installation/quickstart.md
@@ -27,6 +27,7 @@ Getting started on bare metal (no existing Kubernetes cluster):
   - 8080
   - 6443
 - Run the kots intaller command: `curl -sSL https://k8s.kurl.sh/stackblitz | sudo bash`.
+  - *Note:* The KURL installer may prompt some packages for manual installtion. See: [Host Package Requirements](https://kurl.sh/docs/add-ons/kubernetes#host-package-requirements).
 
 :::tip Using load balancers?
 Ports 80 and 443 should be forwarded from the load balancer. The remaining ports are for inbound rules on the security group.

--- a/docs/enterprise/installation/quickstart.md
+++ b/docs/enterprise/installation/quickstart.md
@@ -27,7 +27,8 @@ Getting started on bare metal (no existing Kubernetes cluster):
   - 8080
   - 6443
 - Run the kots intaller command: `curl -sSL https://k8s.kurl.sh/stackblitz | sudo bash`.
-  - *Note:* The KURL installer may prompt some packages for manual installtion. See: [Host Package Requirements](https://kurl.sh/docs/add-ons/kubernetes#host-package-requirements).
+  - **Note:** The KURL installer may prompt some packages for manual installtion. 
+  See: [Host Package Requirements](https://kurl.sh/docs/add-ons/kubernetes#host-package-requirements).
 
 :::tip Using load balancers?
 Ports 80 and 443 should be forwarded from the load balancer. The remaining ports are for inbound rules on the security group.


### PR DESCRIPTION
### Summary of changes

Updates the Stackblitz EE docs to include a reference to required host packages.