### PR TITLE
Correcting some documentation mistakes and typos

### DIFF
--- a/docs/codeflow/integrating-codeflowapp-bot.md
+++ b/docs/codeflow/integrating-codeflowapp-bot.md
@@ -88,7 +88,7 @@ Using pnpm override, you can fix a bug and immediately try it out in the reprodu
 To set up pnpm overrides, follow these steps:
 1. In the project's root directory, create `.stackblitz` directory.
 2. Inside it, create a file called `codeflow.json`.
-3. In the file, specify the overrides by providing a key-vaue pair of the dependency to override and the folder where it is located. Please note that the location is relative to the root of the project.
+3. In the file, specify the overrides by providing a key-value pair of the dependency to override and the folder where it is located. Please note that the location is relative to the root of the project.
 
 ```json
 // .stackblitz/codeflow.json

--- a/docs/guides/user-guide/available-environments.md
+++ b/docs/guides/user-guide/available-environments.md
@@ -63,7 +63,7 @@ WebContainers is StackBlitz's next-generation compute environment, launched in M
 WebContainers offer a native Node.js environment in the browser, making it possible to run both front-end and back-end web frameworks without the limitations associated with polyfills/EngineBlock. For more details on the challenges encountered by our engineering team while developing WebContainers, check out the [Engineering category of our blog here](https://blog.stackblitz.com/categories/engineering/). The WebContainers compute environment can also be consumed headlessly using the [WebContainer API](https://blog.stackblitz.com/posts/webcontainer-api-is-here/), allowing you to develop completely custom UIs on top of this powerful in-browser compute environment.
 
 **Framework Support**  
-With WebContainers, you gain the flexibility to work with virtually any front-end or back-end web framework including Webpack and Vite based variants, a big advantage over the limited framework support of EngineBlock. For applications requiring data storage, you can run a simple database right inside WebContainers using [SQLite3](https://blog.stackblitz.com/posts/introducing-sqlite3-webcontainers-support/). Advanced in-browser image processing can be accomplished [using Sharp](https://blog.stackblitz.com/posts/bringing-sharp-to-wasm-and-webcontainers/). With the more [recent addition of WASI support](https://blog.stackblitz.com/posts/announcing-wasi/),WebContainers now also support a variety of traditionaly native desktop languages & tools, including Python, WordPress plugin development, and jq. With much more to come in the future, WebContainers are the recommended StackBlitz compute environment for most present and future workloads.
+With WebContainers, you gain the flexibility to work with virtually any front-end or back-end web framework including Webpack and Vite based variants, a big advantage over the limited framework support of EngineBlock. For applications requiring data storage, you can run a simple database right inside WebContainers using [SQLite3](https://blog.stackblitz.com/posts/introducing-sqlite3-webcontainers-support/). Advanced in-browser image processing can be accomplished [using Sharp](https://blog.stackblitz.com/posts/bringing-sharp-to-wasm-and-webcontainers/). With the more [recent addition of WASI support](https://blog.stackblitz.com/posts/announcing-wasi/),WebContainers now also support a variety of traditionally native desktop languages & tools, including Python, WordPress plugin development, and jq. With much more to come in the future, WebContainers are the recommended StackBlitz compute environment for most present and future workloads.
 
 **Package Manager Compatibility** <br>
 WebContainers natively support all the major package managers including [npm, pnpm, and yarn v1](https://blog.stackblitz.com/posts/announcing-native-package-manager-support/), just like a local development environment. This offers a more production grade approach to managing dependencies compared to EngineBlock's Turbo v1.
@@ -73,9 +73,9 @@ WebContainers are available in all StackBlitz editors: [Classic Editor](/guides/
 
 ## Which Compute Environment Are You using?
 
-The [Classic Editor](/guides/user-guide/getting-started) supports both EngineBlock and WebContainers compute environments, wheras the [Codeflow](/codeflow/working-in-codeflow-ide) and [Web Publisher](/codeflow/content-updates-with-web-publisher) editors only support WebContainers.
+The [Classic Editor](/guides/user-guide/getting-started) supports both EngineBlock and WebContainers compute environments, whereas the [Codeflow](/codeflow/working-in-codeflow-ide) and [Web Publisher](/codeflow/content-updates-with-web-publisher) editors only support WebContainers.
 
-If clicking the project settings gear opens the VS Code settings dialouge shown below, you are in the **Codeflow editor** and therefore using **WebContainers**:
+If clicking the project settings gear opens the VS Code settings dialogue shown below, you are in the **Codeflow editor** and therefore using **WebContainers**:
 
 ![Screenshot of the Codeflow settings pane](./assets/codeflow-settings.png)
 
@@ -91,6 +91,6 @@ _Project settings for a Classic Editor, WebContainer Project:_
 _Project settings for a Classic Editor, EngineBlock Project:_
 ![Screenshot of the project settings for an EngineBlock project](./assets/engineblock_settings_devserver.png)
 
-And finally, if you see the simplified editing interface pitcured below, you are using the **Web Publisher** editor and therefore the **WebContainers** compute environment:
+And finally, if you see the simplified editing interface pictured below, you are using the **Web Publisher** editor and therefore the **WebContainers** compute environment:
 
 ![Screenshot of StackBlitz Web Publisher](./assets/wp-whole.png)

--- a/docs/guides/user-guide/general-faqs.md
+++ b/docs/guides/user-guide/general-faqs.md
@@ -34,7 +34,7 @@ We support four pathways:
 
 2. If you are using an EngineBlock project, you can deploy directly via our [Firebase integration](https://developer.stackblitz.com/guides/user-guide/ide-whats-on-your-screen#firebase-sidebar).
 
-3. If you are using the Classic Editor, you can click the Connnect Repository button on the top left to easily connect with your desired repository.
+3. If you are using the Classic Editor, you can click the Connect Repository button on the top left to easily connect with your desired repository.
 
 ![Connect repository button on StackBlitz editor](./assets/stackblitz_connecttorepobutton.png)
 


### PR DESCRIPTION
### Summary of changes

Fixed some mistakes (typos) on the documentation text.

-----
<a href="https://stackblitz.com/~/github.com/jrobles98/docs/tree/jrobles98/patch-33252"><img src="https://developer.stackblitz.com/img/review_pr_small.svg" alt="Review PR in StackBlitz" align="left" width="103" height="20"></a> _Submitted with [StackBlitz](https://stackblitz.com/~/github.com/jrobles98/docs/tree/jrobles98/patch-33252)._